### PR TITLE
Add backend Ruff lint baseline

### DIFF
--- a/BACKEND_CI_TODO.md
+++ b/BACKEND_CI_TODO.md
@@ -24,11 +24,11 @@ Suggested branch: `backend-ci-phase-1-health-baseline`
 
 Suggested branch: `backend-ci-phase-2-lint-format`
 
-- [ ] Add a Python linter/formatter setup, likely Ruff.
-- [ ] Keep the initial scope conservative: catch obvious syntax/import/style problems first.
-- [ ] Avoid large formatting churn unless the codebase is already close to compliant.
-- [ ] Add convenient local commands for linting.
-- [ ] Confirm lint passes locally.
+- [x] Add a Python linter/formatter setup, likely Ruff.
+- [x] Keep the initial scope conservative: catch obvious syntax/import/style problems first.
+- [x] Avoid large formatting churn unless the codebase is already close to compliant.
+- [x] Add convenient local commands for linting.
+- [x] Confirm lint passes locally.
 
 ## Phase 3: Backend GitHub Actions CI
 
@@ -65,4 +65,5 @@ Suggested branch: `backend-cd-railway-visibility`
 - [ ] Add database-backed integration tests using a disposable test database.
 - [ ] Add coverage reporting only after tests cover meaningful behavior.
 - [ ] Clean encoding/mojibake comments in touched files when doing nearby maintenance.
+- [ ] Consider a dedicated Ruff formatting branch; `ruff format --check .` currently reports broad churn.
 - [ ] Consider backend security scanning once the basic CI foundation is stable.

--- a/BACKEND_TESTING.md
+++ b/BACKEND_TESTING.md
@@ -9,6 +9,12 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+Run the backend lint baseline:
+
+```bash
+ruff check .
+```
+
 ## Test Environment
 
 The test suite sets safe dummy values in `tests/conftest.py` before importing the FastAPI app. This keeps smoke tests from depending on production Railway, Postgres, S3, email, Google OAuth, or reCAPTCHA settings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+    "E9",
+    "F63",
+    "F7",
+    "F82",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 
 pytest~=8.3.5
+ruff~=0.8.6


### PR DESCRIPTION
## Summary
- Add Ruff as the backend lint baseline
- Configure a conservative rule set focused on syntax/import-level failures
- Document the local backend lint command
- Mark backend CI Phase 2 complete

## Verification
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m pytest`
- `.\.venv\Scripts\python.exe -m compileall app tests`

## Notes
- Full Ruff formatting is intentionally deferred because it would touch many files.
