### PR TITLE
Add Railway deployment status workflow

### DIFF
--- a/.github/workflows/railway-deployment-status.yml
+++ b/.github/workflows/railway-deployment-status.yml
@@ -1,0 +1,23 @@
+name: Railway Deployment Status
+
+on:
+  deployment_status:
+
+jobs:
+  railway-deployment:
+    name: Railway deployment
+    runs-on: ubuntu-latest
+    if: github.event.deployment.ref == 'main'
+
+    steps:
+      - name: Show Railway deployment status
+        run: |
+          echo "Ref: ${{ github.event.deployment.ref }}"
+          echo "Environment: ${{ github.event.deployment_status.environment }}"
+          echo "State: ${{ github.event.deployment_status.state }}"
+          echo "Description: ${{ github.event.deployment_status.description }}"
+          echo "Deployment URL: ${{ github.event.deployment_status.target_url }}"
+
+      - name: Fail on unsuccessful Railway deployment
+        if: github.event.deployment_status.state == 'failure' || github.event.deployment_status.state == 'error'
+        run: exit 1

--- a/BACKEND_CI_TODO.md
+++ b/BACKEND_CI_TODO.md
@@ -54,10 +54,10 @@ Manual GitHub setup after Phase 3 is merged.
 
 Suggested branch: `backend-cd-railway-visibility`
 
-- [ ] Decide whether Railway deployment status should appear in GitHub Actions.
-- [ ] Prefer a read-only deployment-status check if Railway supports it cleanly.
-- [ ] Avoid storing broad or long-lived credentials unless there is no better option.
-- [ ] Document any required GitHub variables/secrets before enabling the job.
+- [x] Decide whether Railway deployment status should appear in GitHub Actions.
+- [x] Prefer a read-only deployment-status check if Railway supports it cleanly.
+- [x] Avoid storing broad or long-lived credentials unless there is no better option.
+- [x] Document any required GitHub variables/secrets before enabling the job.
 
 ## Later
 

--- a/RAILWAY_CD_SETUP.md
+++ b/RAILWAY_CD_SETUP.md
@@ -1,0 +1,35 @@
+# Railway CD Visibility Setup
+
+Railway publishes deployment status events back to GitHub when the backend is connected through Railway's GitHub integration. This repo listens for those GitHub `deployment_status` events and shows a separate `Railway Deployment Status` workflow in GitHub Actions.
+
+## Required Setup
+
+No GitHub secrets or repository variables are required for this phase.
+
+Confirm these are true in Railway:
+
+1. The backend service is connected to the GitHub repo.
+2. GitHub autodeploys are enabled for `main`.
+3. Railway sends deployment status events back to GitHub through its GitHub integration.
+
+## What You Should See
+
+After a merge to `main`:
+
+1. The normal `Backend CI` workflow runs.
+2. Railway deploys the backend through its GitHub integration.
+3. GitHub receives Railway deployment status events.
+4. The `Railway Deployment Status` workflow appears in GitHub Actions and shows:
+   - ref
+   - environment
+   - state
+   - description
+   - deployment URL
+
+If Railway reports a `failure` or `error` deployment state, the workflow fails so the problem is visible in GitHub.
+
+## Notes
+
+- This workflow does not trigger a Railway deployment.
+- Railway remains responsible for deploying the backend.
+- GitHub Actions only mirrors Railway's deployment result into the Actions UI.


### PR DESCRIPTION
## Summary
- Add a Railway Deployment Status workflow that listens for GitHub deployment_status events
- Surface Railway deployment state in GitHub Actions without extra Railway secrets
- Document the expected Railway/GitHub integration behavior
- Mark backend CD visibility phase complete

## Verification
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m pytest`
- `.\.venv\Scripts\python.exe -m compileall app tests`

## Notes
- This does not trigger Railway deployments.
- Railway remains responsible for deploying from GitHub.
