### PR TITLE
Add backend auth and security helper tests

### DIFF
--- a/BACKEND_TEST_COVERAGE_TODO.md
+++ b/BACKEND_TEST_COVERAGE_TODO.md
@@ -23,16 +23,17 @@ Suggested branch: `backend-tests-phase-2-public-routes`
 
 Suggested branch: `backend-tests-phase-3-auth-security`
 
-- [ ] Add password hashing/login helper tests where practical.
-- [ ] Add email token tests.
-- [ ] Add captcha helper tests with mocked network responses.
-- [ ] Add admin dependency tests.
+- [x] Add password hashing/login helper tests where practical.
+- [x] Add email token tests.
+- [x] Add captcha helper tests with mocked network responses.
+- [x] Add admin dependency tests.
 
 ## Phase 4: Route Tests With Mocked Dependencies
 
 Suggested branch: `backend-tests-phase-4-route-mocks`
 
 - [ ] Add route tests for reading lists with mocked sessions.
+- [ ] Add route tests for signup/login password behavior with mocked sessions.
 - [ ] Add route tests for issues with mocked sessions.
 - [ ] Add route tests for forum behavior with mocked sessions.
 - [ ] Add route tests for media validation without touching S3.

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.deps.admin import can_submit_series, get_role_name, is_admin, require_admin, require_series_submitter
+
+pytestmark = pytest.mark.anyio
+
+
+def test_get_role_name_defaults_missing_role_to_general():
+    assert get_role_name(SimpleNamespace()) == "GENERAL"
+
+
+def test_is_admin_returns_true_for_admin_role():
+    assert is_admin(SimpleNamespace(role="admin")) is True
+
+
+def test_can_submit_series_allows_admin_and_contributor_roles():
+    assert can_submit_series(SimpleNamespace(role="ADMIN")) is True
+    assert can_submit_series(SimpleNamespace(role="CONTRIBUTOR")) is True
+
+
+def test_can_submit_series_rejects_general_role():
+    assert can_submit_series(SimpleNamespace(role="GENERAL")) is False
+
+
+async def test_require_admin_returns_admin_user():
+    user = SimpleNamespace(role="ADMIN")
+
+    assert await require_admin(user) is user
+
+
+async def test_require_admin_raises_for_non_admin_user():
+    with pytest.raises(HTTPException) as exc_info:
+        await require_admin(SimpleNamespace(role="GENERAL"))
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Admin access required"
+
+
+async def test_require_series_submitter_returns_contributor_user():
+    user = SimpleNamespace(role="CONTRIBUTOR")
+
+    assert await require_series_submitter(user) is user
+
+
+async def test_require_series_submitter_raises_for_general_user():
+    with pytest.raises(HTTPException) as exc_info:
+        await require_series_submitter(SimpleNamespace(role="GENERAL"))
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Contributor or admin access required"

--- a/tests/captcha_test.py
+++ b/tests/captcha_test.py
@@ -1,0 +1,87 @@
+import pytest
+from fastapi import HTTPException
+
+from app.utils import captcha
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeAsyncClient:
+    def __init__(self, *args, payload=None, error=None, **kwargs):
+        self.payload = payload or {"success": True}
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, *args, **kwargs):
+        if self.error:
+            raise self.error
+        return FakeResponse(self.payload)
+
+
+def test_truthy_detects_enabled_values():
+    assert captcha._truthy("true") is True
+    assert captcha._truthy("1") is True
+    assert captcha._truthy("yes") is True
+    assert captcha._truthy("off") is False
+
+
+async def test_verify_captcha_legacy_accepts_success_response(monkeypatch):
+    monkeypatch.setenv("RECAPTCHA_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(captcha.httpx, "AsyncClient", lambda *args, **kwargs: FakeAsyncClient())
+
+    assert await captcha._verify_captcha_legacy("captcha-token") is None
+
+
+async def test_verify_captcha_legacy_requires_secret_key(monkeypatch):
+    monkeypatch.delenv("RECAPTCHA_SECRET_KEY", raising=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await captcha._verify_captcha_legacy("captcha-token")
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == "Captcha secret key not configured"
+
+
+async def test_verify_captcha_legacy_rejects_failed_response(monkeypatch):
+    monkeypatch.setenv("RECAPTCHA_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(
+        captcha.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: FakeAsyncClient(
+            payload={"success": False, "error-codes": ["invalid-input-response"]}
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await captcha._verify_captcha_legacy("captcha-token")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Captcha verification failed (invalid-input-response)"
+
+
+async def test_verify_captcha_legacy_wraps_network_errors(monkeypatch):
+    monkeypatch.setenv("RECAPTCHA_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(
+        captcha.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: FakeAsyncClient(error=RuntimeError("network down")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await captcha._verify_captcha_legacy("captcha-token")
+
+    assert exc_info.value.status_code == 502
+    assert "Captcha verification request failed" in exc_info.value.detail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 
 def pytest_configure():
     os.environ.setdefault(
@@ -12,3 +14,8 @@ def pytest_configure():
     os.environ.setdefault("AWS_REGION", "us-west-1")
     os.environ.setdefault("AWS_BUCKET_NAME", "toonranks-test")
     os.environ.setdefault("PUBLIC_ORIGIN", "https://www.toonranks.com")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/tests/email_token_utils_test.py
+++ b/tests/email_token_utils_test.py
@@ -1,0 +1,41 @@
+import importlib
+
+import pytest
+from fastapi import HTTPException
+
+import app.utils.email_token_utils as email_token_utils
+
+
+def reload_email_token_utils(monkeypatch, secret_key="test-secret-key-with-at-least-32-characters"):
+    monkeypatch.setenv("SECRET_KEY", secret_key)
+    return importlib.reload(email_token_utils)
+
+
+def test_generate_email_token_round_trips_email_address(monkeypatch):
+    module = reload_email_token_utils(monkeypatch)
+
+    token = module.generate_email_token("reader@example.com")
+
+    assert module.verify_email_token(token) == "reader@example.com"
+
+
+def test_verify_email_token_rejects_invalid_token(monkeypatch):
+    module = reload_email_token_utils(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        module.verify_email_token("not-a-valid-token")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid or expired token"
+
+
+def test_verify_email_token_rejects_token_signed_with_different_secret(monkeypatch):
+    module = reload_email_token_utils(monkeypatch, "first-test-secret-with-at-least-32-characters")
+    token = module.generate_email_token("reader@example.com")
+    module = reload_email_token_utils(monkeypatch, "second-test-secret-with-at-least-32-characters")
+
+    with pytest.raises(HTTPException) as exc_info:
+        module.verify_email_token(token)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid or expired token"


### PR DESCRIPTION
## Summary
- Add tests for admin/contributor role dependencies
- Add mocked reCAPTCHA legacy verification tests
- Add email token generation and verification tests
- Configure AnyIO tests to run with asyncio
- Mark backend test coverage Phase 3 complete

## Verification
- `.\.venv\Scripts\python.exe -m pytest`
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m compileall app tests`

## Notes
- Signup/login password behavior is route-level logic and is tracked for the route-mock phase.
