### PR TITLE
Add backend forum route tests

### DIFF
--- a/BACKEND_TEST_COVERAGE_TODO.md
+++ b/BACKEND_TEST_COVERAGE_TODO.md
@@ -35,7 +35,7 @@ Suggested branch: `backend-tests-phase-4-route-mocks`
 - [x] Add route tests for reading lists with mocked sessions.
 - [x] Add route tests for signup/login password behavior with mocked sessions.
 - [x] Add route tests for issues with mocked sessions.
-- [ ] Add route tests for forum behavior with mocked sessions.
+- [x] Add route tests for forum behavior with mocked sessions.
 - [ ] Add route tests for media validation without touching S3.
 
 ## Phase 5: Database Integration Tests

--- a/tests/forum_routes_test.py
+++ b/tests/forum_routes_test.py
@@ -1,0 +1,274 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.forum_model import ForumPost, ForumReaction, ForumSeriesRef, ForumThread
+from app.models.user_model import User
+from app.routes import forum_routes
+
+
+client = TestClient(app)
+NOW = datetime(2026, 5, 16, tzinfo=timezone.utc)
+
+
+class FakeScalarResult:
+    def __init__(self, *, rows=None, first=None):
+        self._rows = rows or []
+        self._first = first
+
+    def all(self):
+        return self._rows
+
+    def first(self):
+        return self._first
+
+
+class FakeExecuteResult:
+    def __init__(self, *, rows=None, first=None, scalar_one=None):
+        self._rows = rows or []
+        self._first = first
+        self._scalar_one = scalar_one
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        return FakeScalarResult(rows=self._rows, first=self._first)
+
+    def scalar_one(self):
+        return self._scalar_one
+
+
+class FakeForumSession:
+    def __init__(self, *, results=None, get_results=None):
+        self._results = list(results or [])
+        self._get_results = dict(get_results or {})
+        self.added = []
+        self.deleted = []
+        self.committed = False
+        self.flushed = False
+        self.refreshed = []
+
+    async def execute(self, _stmt):
+        return self._results.pop(0)
+
+    async def get(self, model, key):
+        return self._get_results.get((model, key))
+
+    def add(self, item):
+        self.added.append(item)
+
+    async def delete(self, item):
+        self.deleted.append(item)
+
+    async def flush(self):
+        self.flushed = True
+        for index, item in enumerate(self.added, start=1):
+            if getattr(item, "id", None) is None:
+                item.id = index
+            self._fill_timestamps(item)
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, item):
+        self.refreshed.append(item)
+        self._fill_timestamps(item)
+        if getattr(item, "id", None) is None:
+            item.id = 1
+
+    def _fill_timestamps(self, item):
+        if hasattr(item, "created_at"):
+            item.created_at = NOW
+        if hasattr(item, "updated_at"):
+            item.updated_at = NOW
+        if hasattr(item, "last_post_at"):
+            item.last_post_at = NOW
+        if hasattr(item, "post_count") and item.post_count is None:
+            item.post_count = 0
+        if hasattr(item, "locked") and item.locked is None:
+            item.locked = False
+        if hasattr(item, "latest_first") and item.latest_first is None:
+            item.latest_first = False
+        if hasattr(item, "heart_count") and item.heart_count is None:
+            item.heart_count = 0
+
+
+def thread_object(**overrides):
+    values = {
+        "id": 1,
+        "title": "Favorite fights",
+        "author_id": 10,
+        "created_at": NOW,
+        "updated_at": NOW,
+        "post_count": 1,
+        "last_post_at": NOW,
+        "locked": False,
+        "latest_first": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def post_object(**overrides):
+    values = {
+        "id": 5,
+        "thread_id": 1,
+        "author_id": 10,
+        "parent_id": None,
+        "content_markdown": "Great chapter.",
+        "created_at": NOW,
+        "updated_at": NOW,
+        "heart_count": 0,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def override_forum_dependencies(session, *, user=None, viewer=None):
+    current_user = user or SimpleNamespace(id=10, username="reader", role="GENERAL")
+    current_viewer = viewer if viewer is not None else current_user
+
+    async def fake_get_db():
+        yield session
+
+    async def fake_current_user():
+        return current_user
+
+    async def fake_current_user_optional():
+        return current_viewer
+
+    app.dependency_overrides[forum_routes.get_async_session] = fake_get_db
+    app.dependency_overrides[forum_routes.get_current_user] = fake_current_user
+    app.dependency_overrides[forum_routes.get_current_user_optional] = fake_current_user_optional
+
+    def cleanup():
+        app.dependency_overrides.pop(forum_routes.get_async_session, None)
+        app.dependency_overrides.pop(forum_routes.get_current_user, None)
+        app.dependency_overrides.pop(forum_routes.get_current_user_optional, None)
+
+    return cleanup
+
+
+def test_create_thread_creates_thread_first_post_and_series_refs():
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=0),
+            FakeExecuteResult(rows=[]),
+        ],
+        get_results={(User, 10): SimpleNamespace(username="reader")},
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads",
+            json={
+                "title": "Favorite fights",
+                "first_post_markdown": "Which fight had the best paneling?",
+                "series_ids": [101, 102],
+            },
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json()["title"] == "Favorite fights"
+    assert response.json()["author_username"] == "reader"
+    assert session.flushed is True
+    assert session.committed is True
+    assert [type(item) for item in session.added] == [
+        ForumThread,
+        ForumPost,
+        ForumSeriesRef,
+        ForumSeriesRef,
+    ]
+    assert session.added[1].content_markdown == "Which fight had the best paneling?"
+
+
+def test_create_thread_rejects_user_thread_limit():
+    session = FakeForumSession(results=[FakeExecuteResult(scalar_one=10)])
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads",
+            json={
+                "title": "One more thread",
+                "first_post_markdown": "This should hit the limit.",
+            },
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == (
+        "Thread limit reached (10). Delete an existing thread to create a new one."
+    )
+    assert session.added == []
+    assert session.committed is False
+
+
+def test_create_post_rejects_locked_thread_for_non_admin_user():
+    session = FakeForumSession(
+        get_results={(ForumThread, 1): thread_object(locked=True)}
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads/1/posts",
+            json={"content_markdown": "I should not be able to reply."},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 423
+    assert response.json()["detail"] == "Thread is locked"
+    assert session.added == []
+    assert session.committed is False
+
+
+def test_delete_thread_rejects_non_owner_non_admin_user():
+    session = FakeForumSession(
+        get_results={(ForumThread, 1): thread_object(author_id=22)}
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.delete("/forum/threads/1")
+    finally:
+        cleanup()
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admins or the thread owner may delete this thread."
+    assert session.deleted == []
+    assert session.committed is False
+
+
+def test_toggle_heart_adds_reaction_and_returns_count():
+    post = post_object(heart_count=0)
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(first=None),
+            FakeExecuteResult(scalar_one=1),
+        ],
+        get_results={(ForumPost, 5): post},
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post("/forum/threads/1/posts/5/heart")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {"hearted": True, "count": 1}
+    assert session.committed is True
+    assert len(session.added) == 1
+    assert isinstance(session.added[0], ForumReaction)
+    assert session.added[0].post_id == 5
+    assert session.added[0].user_id == 10
+    assert post.heart_count == 1


### PR DESCRIPTION
## Summary
- Add mocked backend route tests for core forum behavior.
- Cover thread creation, thread limits, locked-thread reply protection, delete authorization, and heart toggling.
- Mark forum route test coverage complete in the backend test roadmap.

## Verification
- `.\.venv\Scripts\python.exe -m pytest`
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m compileall app tests`
