### PR TITLE
Add backend database integration test foundation

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -47,7 +47,45 @@ jobs:
         run: python -m pip install -r requirements-dev.txt
 
       - name: Tests
-        run: python -m pytest
+        run: python -m pytest -m "not integration"
+
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: toonranks_test
+          POSTGRES_PASSWORD: toonranks_test
+          POSTGRES_DB: toonranks_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U toonranks_test -d toonranks_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      TEST_DATABASE_URL: postgresql+asyncpg://toonranks_test:toonranks_test@localhost:5432/toonranks_test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Integration tests
+        run: python -m pytest -m integration
 
   syntax-check:
     name: Syntax check

--- a/BACKEND_TESTING.md
+++ b/BACKEND_TESTING.md
@@ -15,6 +15,27 @@ Run the backend lint baseline:
 ruff check .
 ```
 
+## Integration Tests
+
+Integration tests are marked with `@pytest.mark.integration` and require a disposable Postgres
+database through `TEST_DATABASE_URL`.
+
+Run only the normal mocked/unit test suite:
+
+```bash
+pytest -m "not integration"
+```
+
+Run integration tests locally only when you have a disposable test database ready:
+
+```bash
+set TEST_DATABASE_URL=postgresql+asyncpg://toonranks_test:toonranks_test@localhost:5432/toonranks_test
+pytest -m integration
+```
+
+Never point `TEST_DATABASE_URL` at Railway, production, or any long-lived database. The integration
+test setup creates and drops tables in the target database.
+
 ## Test Environment
 
 The test suite sets safe dummy values in `tests/conftest.py` before importing the FastAPI app. This keeps smoke tests from depending on production Railway, Postgres, S3, email, Google OAuth, or reCAPTCHA settings.

--- a/BACKEND_TEST_COVERAGE_TODO.md
+++ b/BACKEND_TEST_COVERAGE_TODO.md
@@ -42,10 +42,10 @@ Suggested branch: `backend-tests-phase-4-route-mocks`
 
 Suggested branch: `backend-tests-phase-5-db-integration`
 
-- [ ] Decide on disposable Postgres strategy for CI.
-- [ ] Add test database setup/teardown.
+- [x] Decide on disposable Postgres strategy for CI.
+- [x] Add test database setup/teardown.
 - [ ] Add integration tests for core CRUD flows.
-- [ ] Keep production database credentials out of tests.
+- [x] Keep production database credentials out of tests.
 
 ## Later
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = tests
 pythonpath = .
 python_files = *_test.py
+markers =
+    integration: tests that require a disposable database or external test service

--- a/tests/db_integration_test.py
+++ b/tests/db_integration_test.py
@@ -1,0 +1,106 @@
+import importlib
+import os
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from app.database import Base
+from app.models.user_model import User
+
+
+pytestmark = pytest.mark.integration
+
+
+MODEL_MODULES = [
+    "app.models.forum_media_model",
+    "app.models.forum_model",
+    "app.models.issue",
+    "app.models.reading_list",
+    "app.models.series_detail",
+    "app.models.series_model",
+    "app.models.user_model",
+    "app.models.user_vote",
+]
+
+
+def load_models_for_metadata():
+    for module_name in MODEL_MODULES:
+        importlib.import_module(module_name)
+
+
+def get_test_database_url():
+    database_url = os.getenv("TEST_DATABASE_URL")
+    if not database_url:
+        pytest.skip("TEST_DATABASE_URL is not set")
+    forbidden_fragments = ("railway.app", "amazonaws.com", "prod", "production")
+    if any(fragment in database_url.lower() for fragment in forbidden_fragments):
+        pytest.fail("TEST_DATABASE_URL must point to a disposable test database")
+    return database_url.replace("postgresql://", "postgresql+asyncpg://")
+
+
+async def prepare_schema(conn):
+    await conn.execute(text('CREATE SCHEMA IF NOT EXISTS "man_review";'))
+    await conn.execute(
+        text(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_type t
+                    JOIN pg_namespace n ON n.oid = t.typnamespace
+                    WHERE t.typname = 'series_status'
+                    AND n.nspname = 'man_review'
+                ) THEN
+                    CREATE TYPE man_review.series_status AS ENUM (
+                        'ONGOING',
+                        'COMPLETE',
+                        'HIATUS',
+                        'UNKNOWN',
+                        'SEASON_END'
+                    );
+                END IF;
+            END
+            $$;
+            """
+        )
+    )
+
+
+@pytest.mark.anyio
+async def test_database_metadata_and_user_crud_round_trip():
+    database_url = get_test_database_url()
+    load_models_for_metadata()
+    engine = create_async_engine(database_url, echo=False, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with engine.begin() as conn:
+            await prepare_schema(conn)
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            user = User(
+                username="integration-reader",
+                password="hashed-password",
+                email="integration@example.com",
+                is_verified=True,
+            )
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+
+            found = await session.get(User, user.id)
+            assert found is not None
+            assert found.username == "integration-reader"
+            assert found.email == "integration@example.com"
+
+            await session.delete(found)
+            await session.commit()
+            assert await session.get(User, user.id) is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- Add a dedicated backend integration-test CI job with disposable Postgres.
- Add pytest integration marker and keep normal tests separate from DB-backed tests.
- Add a guarded database metadata/User CRUD integration test.
- Document local integration test usage and production credential safety.

## Verification
- `.\.venv\Scripts\python.exe -m pytest -m "not integration"`
- `.\.venv\Scripts\python.exe -m pytest -m integration`
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m compileall app tests`
