### PR TITLE
Add backend core CRUD integration test

### DIFF
--- a/BACKEND_TEST_COVERAGE_TODO.md
+++ b/BACKEND_TEST_COVERAGE_TODO.md
@@ -44,7 +44,7 @@ Suggested branch: `backend-tests-phase-5-db-integration`
 
 - [x] Decide on disposable Postgres strategy for CI.
 - [x] Add test database setup/teardown.
-- [ ] Add integration tests for core CRUD flows.
+- [x] Add integration tests for core CRUD flows.
 - [x] Keep production database credentials out of tests.
 
 ## Later

--- a/tests/db_integration_test.py
+++ b/tests/db_integration_test.py
@@ -2,10 +2,13 @@ import importlib
 import os
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy.orm import selectinload
 
 from app.database import Base
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series_model import Series, SeriesStatus, SeriesType
 from app.models.user_model import User
 
 
@@ -41,6 +44,7 @@ def get_test_database_url():
 
 async def prepare_schema(conn):
     await conn.execute(text('CREATE SCHEMA IF NOT EXISTS "man_review";'))
+    await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto;"))
     await conn.execute(
         text(
             """
@@ -100,6 +104,85 @@ async def test_database_metadata_and_user_crud_round_trip():
             await session.delete(found)
             await session.commit()
             assert await session.get(User, user.id) is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_database_user_series_and_reading_list_crud_flow():
+    database_url = get_test_database_url()
+    load_models_for_metadata()
+    engine = create_async_engine(database_url, echo=False, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with engine.begin() as conn:
+            await prepare_schema(conn)
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            user = User(
+                username="reading-list-reader",
+                password="hashed-password",
+                email="reading-list@example.com",
+                is_verified=True,
+            )
+            series = Series(
+                title="Integration Series",
+                genre="Action",
+                type=SeriesType.MANHWA,
+                status=SeriesStatus.ONGOING,
+                approval_status="APPROVED",
+            )
+            session.add_all([user, series])
+            await session.commit()
+            await session.refresh(user)
+            await session.refresh(series)
+
+            reading_list = ReadingList(user_id=user.id, name="Weekend Reads")
+            session.add(reading_list)
+            await session.commit()
+            await session.refresh(reading_list)
+
+            item = ReadingListItem(
+                list_id=reading_list.id,
+                series_id=series.id,
+                left_off_chapter="Chapter 12",
+            )
+            session.add(item)
+            await session.commit()
+
+            result = await session.execute(
+                select(ReadingList)
+                .where(ReadingList.id == reading_list.id)
+                .options(selectinload(ReadingList.items))
+            )
+            found_list = result.scalars().first()
+
+            assert found_list is not None
+            assert found_list.user_id == user.id
+            assert found_list.share_token is not None
+            assert len(found_list.items) == 1
+            assert found_list.items[0].series_id == series.id
+            assert found_list.items[0].left_off_chapter == "Chapter 12"
+
+            await session.delete(user)
+            await session.commit()
+
+            list_count = (
+                await session.execute(select(func.count(ReadingList.id)))
+            ).scalar_one()
+            item_count = (
+                await session.execute(select(func.count(ReadingListItem.id)))
+            ).scalar_one()
+            series_count = (await session.execute(select(func.count(Series.id)))).scalar_one()
+
+            assert list_count == 0
+            assert item_count == 0
+            assert series_count == 1
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)


### PR DESCRIPTION
## Summary
- Add a DB-backed integration test for a user, series, reading-list, and reading-list item CRUD flow.
- Verify reading-list item persistence and user-delete cascade behavior.
- Enable pgcrypto in disposable test DB setup for generated reading-list share tokens.
- Mark Phase 5 core CRUD integration coverage complete.

## Verification
- `.\.venv\Scripts\python.exe -m pytest -m "not integration"`
- `.\.venv\Scripts\python.exe -m pytest -m integration`
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m compileall app tests`
