### PR TITLE
Add backend JUnit test report artifacts

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -47,7 +47,15 @@ jobs:
         run: python -m pip install -r requirements-dev.txt
 
       - name: Tests
-        run: python -m pytest -m "not integration"
+        run: python -m pytest -m "not integration" --junitxml=test-results/pytest-unit.xml
+
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-unit-test-report
+          path: test-results/pytest-unit.xml
+          if-no-files-found: error
 
   integration-tests:
     name: Integration tests
@@ -85,7 +93,15 @@ jobs:
         run: python -m pip install -r requirements-dev.txt
 
       - name: Integration tests
-        run: python -m pytest -m integration
+        run: python -m pytest -m integration --junitxml=test-results/pytest-integration.xml
+
+      - name: Upload integration test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-integration-test-report
+          path: test-results/pytest-integration.xml
+          if-no-files-found: error
 
   syntax-check:
     name: Syntax check

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .idea/
 .DS_Store
 *.sqlite3
+test-results/

--- a/BACKEND_TESTING.md
+++ b/BACKEND_TESTING.md
@@ -36,6 +36,17 @@ pytest -m integration
 Never point `TEST_DATABASE_URL` at Railway, production, or any long-lived database. The integration
 test setup creates and drops tables in the target database.
 
+## CI Test Reports
+
+GitHub Actions writes pytest JUnit XML reports for the unit and integration test jobs, then uploads
+them as workflow artifacts:
+
+- `backend-unit-test-report`
+- `backend-integration-test-report`
+
+The local `test-results/` folder is ignored by git, so you can generate reports locally without
+accidentally committing them.
+
 ## Test Environment
 
 The test suite sets safe dummy values in `tests/conftest.py` before importing the FastAPI app. This keeps smoke tests from depending on production Railway, Postgres, S3, email, Google OAuth, or reCAPTCHA settings.

--- a/BACKEND_TEST_COVERAGE_TODO.md
+++ b/BACKEND_TEST_COVERAGE_TODO.md
@@ -50,5 +50,5 @@ Suggested branch: `backend-tests-phase-5-db-integration`
 ## Later
 
 - [ ] Add coverage reporting once tests cover meaningful behavior.
-- [ ] Add JUnit pytest reports and upload them in GitHub Actions for clearer per-test failure summaries.
+- [x] Add JUnit pytest reports and upload them in GitHub Actions for clearer per-test failure summaries.
 - [ ] Add regression tests when production bugs are found.


### PR DESCRIPTION
## Summary
- Generate JUnit XML reports for backend unit and integration test jobs.
- Upload the reports as GitHub Actions artifacts.
- Ignore local `test-results/` output and document CI test reports.

## Verification
- `.\.venv\Scripts\python.exe -m pytest -m "not integration" --junitxml=test-results\pytest-unit.xml`
- `.\.venv\Scripts\python.exe -m pytest -m integration --junitxml=test-results\pytest-integration.xml`
- `.\.venv\Scripts\python.exe -m ruff check .`
- `.\.venv\Scripts\python.exe -m compileall app tests`
