### PR TITLE
Add backend avatar model and account APIs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -128,6 +128,31 @@ async def on_startup():
                 await conn.execute(
                     text(
                         """
+                        ALTER TABLE IF EXISTS man_review.users
+                        ADD COLUMN IF NOT EXISTS avatar_url VARCHAR
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
+                        ALTER TABLE IF EXISTS man_review.users
+                        ADD COLUMN IF NOT EXISTS avatar_preset VARCHAR
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
+                        UPDATE man_review.users
+                        SET avatar_preset = 'blue'
+                        WHERE avatar_preset IS NULL
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
                         UPDATE man_review.series
                         SET approval_status = 'APPROVED'
                         WHERE approval_status IS NULL

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -13,6 +13,8 @@ class User(Base):
     role = Column(String, default="GENERAL")  # GENERAL, CONTRIBUTOR, or ADMIN
     email = Column(String, unique=True, index=True, nullable=True)
     is_verified = Column(Boolean, default=False, nullable=False, server_default="false")
+    avatar_url = Column(String, nullable=True)
+    avatar_preset = Column(String, nullable=True, default="blue")
 
     registered_at = Column(DateTime(timezone=True), nullable=True)
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,35 +1,84 @@
 from fastapi import (APIRouter, Depends, HTTPException,
-                     status, Query, Body)
+                     status, Query, Body, UploadFile, File)
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import AsyncSessionLocal
 from app.email_service import send_verification_email
 from app.limiter import limiter
 from app.models.user_model import User
-from app.schemas.user_schemas import UserCreate, UserOut, SignupResponse, UserLogin, ResendVerification, UserAdminOut, UserRoleUpdate
+from app.schemas.user_schemas import (
+    AvatarPresetUpdate,
+    ResendVerification,
+    SignupResponse,
+    UserAdminOut,
+    UserAvatarOut,
+    UserCreate,
+    UserLogin,
+    UserOut,
+    UserRoleUpdate,
+)
 from sqlalchemy.future import select
 from passlib.hash import bcrypt
 from fastapi.responses import JSONResponse
 from fastapi import Request
+from PIL import Image, ImageOps
 
 from app.utils.captcha import verify_captcha
-from app.utils.token_utils import create_access_token
+from app.utils.token_utils import create_access_token, get_current_user
 from app.utils.email_token_utils import verify_email_token, generate_email_token
 from google.oauth2 import id_token
 from google.auth.transport import requests
 from datetime import datetime, timezone
 import os
 import json
+import io
 from urllib.parse import urlencode
 from urllib.request import urlopen
 from jose import JWTError
 from app.deps.admin import require_admin
+from app.s3 import upload_to_s3
 
 router = APIRouter()
+
+DEFAULT_AVATAR_PRESET = "blue"
+ALLOWED_AVATAR_PRESETS = {"blue", "emerald", "amber"}
+ALLOWED_AVATAR_MIMES = {"image/png", "image/jpeg", "image/webp"}
+MAX_AVATAR_BYTES = 5 * 1024 * 1024
+AVATAR_SIZE = 256
 
 async def get_db():
     async with AsyncSessionLocal() as session:
         yield session
+
+
+def user_to_dict(user: User) -> dict:
+    return {
+        "id": user.id,
+        "username": user.username,
+        "role": user.role,
+        "avatar_url": getattr(user, "avatar_url", None),
+        "avatar_preset": getattr(user, "avatar_preset", None) or DEFAULT_AVATAR_PRESET,
+    }
+
+
+def normalize_avatar_image(blob: bytes) -> io.BytesIO:
+    try:
+        with Image.open(io.BytesIO(blob)) as image:
+            image = ImageOps.exif_transpose(image)
+            image = ImageOps.fit(image.convert("RGB"), (AVATAR_SIZE, AVATAR_SIZE))
+            out = io.BytesIO()
+            image.save(out, format="WEBP", quality=88, method=6)
+            out.seek(0)
+            return out
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid avatar image")
+
+
+async def get_user_for_update(current_user: User, db: AsyncSession) -> User:
+    user = await db.get(User, current_user.id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
 
 
 
@@ -61,6 +110,7 @@ async def signup(request: Request, user: UserCreate, db: AsyncSession = Depends(
         password=hashed,
         email=email_norm,           # store normalized email
         is_verified=False,
+        avatar_preset=DEFAULT_AVATAR_PRESET,
         registered_at=datetime.now(timezone.utc),
     )
 
@@ -156,6 +206,7 @@ async def google_oauth(payload: dict, db: AsyncSession = Depends(get_db)):
                 password="",
                 is_verified=True,
                 role="GENERAL",
+                avatar_preset=DEFAULT_AVATAR_PRESET,
                 registered_at=datetime.now(timezone.utc),
             )
             db.add(user)
@@ -166,7 +217,7 @@ async def google_oauth(payload: dict, db: AsyncSession = Depends(get_db)):
 
         return {
             "access_token": access_token,
-            "user": {"id": user.id, "username": user.username, "role": user.role},
+            "user": user_to_dict(user),
         }
     except Exception:
         raise HTTPException(status_code=401, detail="Invalid Google token")
@@ -207,7 +258,7 @@ async def login(request: Request, user: UserLogin, db: AsyncSession = Depends(ge
 
     return JSONResponse({
         "access_token": access_token,
-        "user": {"id": db_user.id, "username": db_user.username, "role": db_user.role}
+        "user": user_to_dict(db_user)
     })
 
 
@@ -330,3 +381,65 @@ async def update_user_role(
     await db.commit()
     await db.refresh(user)
     return user
+
+
+@router.post("/me/avatar", response_model=UserAvatarOut)
+async def upload_my_avatar(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if file.content_type not in ALLOWED_AVATAR_MIMES:
+        raise HTTPException(status_code=400, detail="Unsupported avatar image type")
+
+    blob = await file.read()
+    if not blob:
+        raise HTTPException(status_code=400, detail="Avatar image is empty")
+    if len(blob) > MAX_AVATAR_BYTES:
+        raise HTTPException(status_code=400, detail="Avatar image is too large")
+
+    avatar_url = upload_to_s3(
+        normalize_avatar_image(blob),
+        filename="avatar.webp",
+        content_type="image/webp",
+        folder="avatars",
+        subfolder=str(current_user.id),
+    )
+
+    user = await get_user_for_update(current_user, db)
+    user.avatar_url = avatar_url
+    user.avatar_preset = user.avatar_preset or DEFAULT_AVATAR_PRESET
+    await db.commit()
+    await db.refresh(user)
+    return user_to_dict(user)
+
+
+@router.patch("/me/avatar/preset", response_model=UserAvatarOut)
+async def select_my_avatar_preset(
+    payload: AvatarPresetUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    next_preset = (payload.avatar_preset or "").strip().lower()
+    if next_preset not in ALLOWED_AVATAR_PRESETS:
+        raise HTTPException(status_code=400, detail="Invalid avatar preset")
+
+    user = await get_user_for_update(current_user, db)
+    user.avatar_url = None
+    user.avatar_preset = next_preset
+    await db.commit()
+    await db.refresh(user)
+    return user_to_dict(user)
+
+
+@router.delete("/me/avatar", response_model=UserAvatarOut)
+async def reset_my_avatar(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await get_user_for_update(current_user, db)
+    user.avatar_url = None
+    user.avatar_preset = user.avatar_preset or DEFAULT_AVATAR_PRESET
+    await db.commit()
+    await db.refresh(user)
+    return user_to_dict(user)

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -19,6 +19,8 @@ class UserOut(BaseModel):
     id: int
     username: str
     role: str
+    avatar_url: Optional[str] = None
+    avatar_preset: Optional[str] = "blue"
 
 class UserAdminOut(UserOut):
     email: Optional[EmailStr] = None
@@ -26,6 +28,16 @@ class UserAdminOut(UserOut):
 
 class UserRoleUpdate(BaseModel):
     role: str
+
+class AvatarPresetUpdate(BaseModel):
+    avatar_preset: str
+
+class UserAvatarOut(BaseModel):
+    id: int
+    username: str
+    role: str
+    avatar_url: Optional[str] = None
+    avatar_preset: str
 
 class SignupResponse(BaseModel):
     message: str

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,6 +1,8 @@
+import io
 from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
+from PIL import Image
 
 from app.main import app
 from app.routes import auth
@@ -34,8 +36,9 @@ class FakeExecuteResult:
 
 
 class FakeAuthSession:
-    def __init__(self, *, execute_result=None):
+    def __init__(self, *, execute_result=None, get_result=None):
         self.execute_result = execute_result or FakeExecuteResult()
+        self.get_result = get_result
         self.added = []
         self.committed = False
         self.flushed = False
@@ -44,6 +47,9 @@ class FakeAuthSession:
 
     async def execute(self, _stmt):
         return self.execute_result
+
+    async def get(self, _model, _id):
+        return self.get_result
 
     def add(self, item):
         self.added.append(item)
@@ -71,8 +77,22 @@ def override_auth_db(session):
     return lambda: app.dependency_overrides.pop(auth.get_db, None)
 
 
+def override_auth_user(user):
+    async def fake_current_user():
+        return user
+
+    app.dependency_overrides[auth.get_current_user] = fake_current_user
+    return lambda: app.dependency_overrides.pop(auth.get_current_user, None)
+
+
 async def fake_verify_captcha(*args, **kwargs):
     return None
+
+
+def make_image_bytes(*, size=(64, 48), image_format="PNG"):
+    buffer = io.BytesIO()
+    Image.new("RGB", size, color=(32, 96, 160)).save(buffer, format=image_format)
+    return buffer.getvalue()
 
 
 def test_signup_creates_unverified_user_with_normalized_email(monkeypatch):
@@ -202,7 +222,13 @@ def test_login_returns_access_token_for_verified_user(monkeypatch):
     assert response.status_code == 200
     assert response.json() == {
         "access_token": "token-for-reader",
-        "user": {"id": 7, "username": "reader", "role": "GENERAL"},
+        "user": {
+            "id": 7,
+            "username": "reader",
+            "role": "GENERAL",
+            "avatar_url": None,
+            "avatar_preset": "blue",
+        },
     }
 
 
@@ -262,3 +288,179 @@ def test_login_rejects_unverified_user(monkeypatch):
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Email not verified"
+
+
+def test_normalize_avatar_image_returns_square_webp():
+    output = auth.normalize_avatar_image(make_image_bytes(size=(80, 40)))
+
+    with Image.open(output) as image:
+        assert image.size == (auth.AVATAR_SIZE, auth.AVATAR_SIZE)
+        assert image.format == "WEBP"
+
+
+def test_upload_my_avatar_normalizes_and_persists_url(monkeypatch):
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    db_user = SimpleNamespace(
+        id=7,
+        username="reader",
+        role="GENERAL",
+        avatar_url=None,
+        avatar_preset=None,
+    )
+    session = FakeAuthSession(get_result=db_user)
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+    uploaded = []
+
+    def fake_upload(fileobj, filename, content_type, folder, subfolder):
+        uploaded.append(
+            {
+                "bytes": fileobj.read(),
+                "filename": filename,
+                "content_type": content_type,
+                "folder": folder,
+                "subfolder": subfolder,
+            }
+        )
+        return "https://cdn.example.com/avatars/7/avatar.webp"
+
+    monkeypatch.setattr(auth, "upload_to_s3", fake_upload)
+
+    try:
+        response = client.post(
+            "/auth/me/avatar",
+            files={"file": ("avatar.png", make_image_bytes(), "image/png")},
+        )
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 7,
+        "username": "reader",
+        "role": "GENERAL",
+        "avatar_url": "https://cdn.example.com/avatars/7/avatar.webp",
+        "avatar_preset": "blue",
+    }
+    assert session.committed is True
+    assert uploaded[0]["filename"] == "avatar.webp"
+    assert uploaded[0]["content_type"] == "image/webp"
+    assert uploaded[0]["folder"] == "avatars"
+    assert uploaded[0]["subfolder"] == "7"
+
+    with Image.open(io.BytesIO(uploaded[0]["bytes"])) as image:
+        assert image.size == (auth.AVATAR_SIZE, auth.AVATAR_SIZE)
+        assert image.format == "WEBP"
+
+
+def test_upload_my_avatar_rejects_unsupported_file_without_s3(monkeypatch):
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    session = FakeAuthSession(get_result=current_user)
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+    monkeypatch.setattr(
+        auth,
+        "upload_to_s3",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("S3 called")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/me/avatar",
+            files={"file": ("avatar.txt", b"hello", "text/plain")},
+        )
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported avatar image type"
+    assert session.committed is False
+
+
+def test_select_my_avatar_preset_clears_custom_avatar():
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    db_user = SimpleNamespace(
+        id=7,
+        username="reader",
+        role="GENERAL",
+        avatar_url="https://cdn.example.com/custom.webp",
+        avatar_preset="blue",
+    )
+    session = FakeAuthSession(get_result=db_user)
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+
+    try:
+        response = client.patch(
+            "/auth/me/avatar/preset",
+            json={"avatar_preset": "emerald"},
+        )
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 7,
+        "username": "reader",
+        "role": "GENERAL",
+        "avatar_url": None,
+        "avatar_preset": "emerald",
+    }
+    assert db_user.avatar_url is None
+    assert db_user.avatar_preset == "emerald"
+    assert session.committed is True
+
+
+def test_select_my_avatar_preset_rejects_unknown_preset():
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    session = FakeAuthSession(get_result=current_user)
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+
+    try:
+        response = client.patch(
+            "/auth/me/avatar/preset",
+            json={"avatar_preset": "purple"},
+        )
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid avatar preset"
+    assert session.committed is False
+
+
+def test_reset_my_avatar_clears_custom_avatar():
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    db_user = SimpleNamespace(
+        id=7,
+        username="reader",
+        role="GENERAL",
+        avatar_url="https://cdn.example.com/custom.webp",
+        avatar_preset=None,
+    )
+    session = FakeAuthSession(get_result=db_user)
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+
+    try:
+        response = client.delete("/auth/me/avatar")
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 7,
+        "username": "reader",
+        "role": "GENERAL",
+        "avatar_url": None,
+        "avatar_preset": "blue",
+    }
+    assert db_user.avatar_url is None
+    assert db_user.avatar_preset == "blue"
+    assert session.committed is True


### PR DESCRIPTION
## Summary
- Adds avatar fields to users and startup DB setup for existing deployments.
- Extends auth/user responses with avatar URL and preset metadata.
- Adds account avatar upload, preset selection, and reset endpoints.
- Normalizes uploaded avatars to 256x256 WebP before S3 upload.
- Adds backend tests for avatar normalization, upload validation, preset selection, and reset behavior.

## Verification
- .\.venv\Scripts\python.exe -m pytest
- .\.venv\Scripts\python.exe -m ruff check app tests
- .\.venv\Scripts\python.exe -m compileall app tests
- git diff --check