### PR TITLE
Add avatar metadata to forum responses

### DIFF
--- a/app/routes/forum_routes.py
+++ b/app/routes/forum_routes.py
@@ -24,6 +24,7 @@ from app.limiter import limiter
 from app.moderation.profanity import ensure_clean
 
 router = APIRouter(prefix="/forum", tags=["forum"])
+DEFAULT_AVATAR_PRESET = "blue"
 
 
 class LockToggleIn(BaseModel):
@@ -58,6 +59,17 @@ async def _post_heart_bits(db: AsyncSession, post_id: int, viewer_id: Optional[i
 def _is_admin(user: "User") -> bool:
     return (getattr(user, "role", "") or "").upper() == "ADMIN"
 
+
+def _author_profile(user: Optional[User]) -> dict:
+    return {
+        "author_username": getattr(user, "username", None) if user else None,
+        "author_avatar_url": getattr(user, "avatar_url", None) if user else None,
+        "author_avatar_preset": (
+            getattr(user, "avatar_preset", None) if user else None
+        ) or DEFAULT_AVATAR_PRESET,
+    }
+
+
 async def _post_to_plain_dict(p: ForumPost, db: AsyncSession, viewer: Optional["User"]=None) -> dict:
     refs = await db.execute(
         select(ForumSeriesRef, Series)
@@ -74,17 +86,17 @@ async def _post_to_plain_dict(p: ForumPost, db: AsyncSession, viewer: Optional["
             "status": s.status,
         })
 
-    author_username = None
+    author = None
     if p.author_id:
-        u = await db.get(User, p.author_id)
-        author_username = getattr(u, "username", None) if u else None
+        author = await db.get(User, p.author_id)
 
     heart_count, viewer_has = await _post_heart_bits(db, p.id, getattr(viewer, "id", None))
+    author_profile = _author_profile(author)
 
     # Always include parent_id; use 0 for top-level
     return {
         "id": p.id,
-        "author_username": author_username,
+        **author_profile,
         "content_markdown": p.content_markdown,
         "created_at": str(p.created_at),
         "updated_at": str(p.updated_at),
@@ -123,10 +135,9 @@ async def get_current_user_optional(
 # Mappers
 # ------------------------------
 async def _thread_to_out(t: ForumThread, db: AsyncSession) -> ForumThreadOut:
-    author_username: Optional[str] = None
+    author = None
     if t.author_id:
-        u = await db.get(User, t.author_id)
-        author_username = getattr(u, "username", None) if u else None
+        author = await db.get(User, t.author_id)
 
     refs = await db.execute(
         select(ForumSeriesRef, Series)
@@ -147,7 +158,7 @@ async def _thread_to_out(t: ForumThread, db: AsyncSession) -> ForumThreadOut:
     return ForumThreadOut(
         id=t.id,
         title=t.title,
-        author_username=author_username,
+        **_author_profile(author),
         created_at=str(t.created_at),
         updated_at=str(t.updated_at),
         post_count=t.post_count or 0,
@@ -174,16 +185,15 @@ async def _post_to_out(p: ForumPost, db: AsyncSession, viewer: Optional["User"]=
         for (_ref, s) in refs.all()
     ]
 
-    author_username: Optional[str] = None
+    author = None
     if p.author_id:
-        u = await db.get(User, p.author_id)
-        author_username = getattr(u, "username", None) if u else None
+        author = await db.get(User, p.author_id)
 
     heart_count, viewer_has = await _post_heart_bits(db, p.id, getattr(viewer, "id", None))
 
     return ForumPostOut(
         id=p.id,
-        author_username=author_username,
+        **_author_profile(author),
         content_markdown=p.content_markdown,
         created_at=str(p.created_at),
         updated_at=str(p.updated_at),

--- a/app/schemas/forum_schemas.py
+++ b/app/schemas/forum_schemas.py
@@ -15,6 +15,8 @@ class SeriesRefOut(BaseModel):
 class ForumPostOut(BaseModel):
     id: int
     author_username: Optional[str] = None
+    author_avatar_url: Optional[str] = None
+    author_avatar_preset: Optional[str] = "blue"
     content_markdown: str
     created_at: str
     updated_at: str
@@ -28,6 +30,8 @@ class ForumThreadOut(BaseModel):
     id: int
     title: str
     author_username: Optional[str] = None
+    author_avatar_url: Optional[str] = None
+    author_avatar_preset: Optional[str] = "blue"
     created_at: str
     updated_at: str
     post_count: int

--- a/tests/forum_routes_test.py
+++ b/tests/forum_routes_test.py
@@ -158,7 +158,13 @@ def test_create_thread_creates_thread_first_post_and_series_refs():
             FakeExecuteResult(scalar_one=0),
             FakeExecuteResult(rows=[]),
         ],
-        get_results={(User, 10): SimpleNamespace(username="reader")},
+        get_results={
+            (User, 10): SimpleNamespace(
+                username="reader",
+                avatar_url="https://cdn.example.com/avatar.webp",
+                avatar_preset="emerald",
+            )
+        },
     )
     cleanup = override_forum_dependencies(session)
 
@@ -177,6 +183,8 @@ def test_create_thread_creates_thread_first_post_and_series_refs():
     assert response.status_code == 200
     assert response.json()["title"] == "Favorite fights"
     assert response.json()["author_username"] == "reader"
+    assert response.json()["author_avatar_url"] == "https://cdn.example.com/avatar.webp"
+    assert response.json()["author_avatar_preset"] == "emerald"
     assert session.flushed is True
     assert session.committed is True
     assert [type(item) for item in session.added] == [
@@ -229,6 +237,39 @@ def test_create_post_rejects_locked_thread_for_non_admin_user():
     assert response.json()["detail"] == "Thread is locked"
     assert session.added == []
     assert session.committed is False
+
+
+def test_create_post_returns_author_avatar_metadata():
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(rows=[]),
+            FakeExecuteResult(scalar_one=0),
+        ],
+        get_results={
+            (ForumThread, 1): thread_object(),
+            (User, 10): SimpleNamespace(
+                username="reader",
+                avatar_url=None,
+                avatar_preset="amber",
+            ),
+        },
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads/1/posts",
+            json={"content_markdown": "This chapter worked well."},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json()["author_username"] == "reader"
+    assert response.json()["author_avatar_url"] is None
+    assert response.json()["author_avatar_preset"] == "amber"
+    assert session.flushed is True
+    assert session.committed is True
 
 
 def test_delete_thread_rejects_non_owner_non_admin_user():


### PR DESCRIPTION
## Summary
- Adds author avatar URL and preset fields to forum thread and post response schemas.
- Populates avatar metadata from the thread/post author when mapping forum responses.
- Keeps existing author_username fields intact for backward compatibility.
- Adds forum route tests for avatar metadata on created threads and posts.

## Verification
- .\.venv\Scripts\python.exe -m pytest
- .\.venv\Scripts\python.exe -m ruff check app tests
- .\.venv\Scripts\python.exe -m compileall app tests
- git diff --check