### PR TITLE
Add backend mobile auth code exchange

### DIFF
--- a/app/models/mobile_auth_code.py
+++ b/app/models/mobile_auth_code.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class MobileAuthCode(Base):
+    __tablename__ = "mobile_auth_codes"
+    __table_args__ = {"schema": "man_review"}
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("man_review.users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    code_hash = Column(String(128), unique=True, nullable=False, index=True)
+    redirect_uri = Column(String(255), nullable=False)
+    state = Column(String(255), nullable=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used_at = Column(DateTime(timezone=True), nullable=True)
+
+    user = relationship("User")

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -22,19 +22,24 @@ from passlib.hash import bcrypt
 from fastapi.responses import JSONResponse
 from fastapi import Request
 from PIL import Image, ImageOps
+from pydantic import BaseModel
 
+from app.models.mobile_auth_code import MobileAuthCode
 from app.utils.captcha import verify_captcha
 from app.utils.token_utils import create_access_token, get_current_user
 from app.utils.email_token_utils import verify_email_token, generate_email_token
 from google.oauth2 import id_token
 from google.auth.transport import requests
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 import json
 import io
+import hashlib
+import secrets
 from urllib.parse import urlencode
 from urllib.request import urlopen
 from jose import JWTError
+from typing import Optional
 from app.deps.admin import require_admin
 from app.s3 import upload_to_s3
 
@@ -45,6 +50,17 @@ ALLOWED_AVATAR_PRESETS = {"blue", "emerald", "amber"}
 ALLOWED_AVATAR_MIMES = {"image/png", "image/jpeg", "image/webp"}
 MAX_AVATAR_BYTES = 5 * 1024 * 1024
 AVATAR_SIZE = 256
+MOBILE_AUTH_CODE_EXPIRE_SECONDS = 5 * 60
+ALLOWED_MOBILE_AUTH_REDIRECT_URIS = {"toonranks://auth/callback"}
+
+
+class MobileAuthCodeCreate(BaseModel):
+    redirect_uri: str
+    state: Optional[str] = None
+
+
+class MobileAuthTokenExchange(BaseModel):
+    code: str
 
 async def get_db():
     async with AsyncSessionLocal() as session:
@@ -74,11 +90,98 @@ def normalize_avatar_image(blob: bytes) -> io.BytesIO:
         raise HTTPException(status_code=400, detail="Invalid avatar image")
 
 
+def hash_mobile_auth_code(code: str) -> str:
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()
+
+
+def is_allowed_mobile_redirect_uri(redirect_uri: str) -> bool:
+    return redirect_uri in ALLOWED_MOBILE_AUTH_REDIRECT_URIS
+
+
+def mobile_auth_code_expired(expires_at: datetime) -> bool:
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at <= datetime.now(timezone.utc)
+
+
 async def get_user_for_update(current_user: User, db: AsyncSession) -> User:
     user = await db.get(User, current_user.id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
+
+
+@router.post("/mobile-code")
+async def create_mobile_auth_code(
+    payload: MobileAuthCodeCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    redirect_uri = payload.redirect_uri.strip()
+    if not is_allowed_mobile_redirect_uri(redirect_uri):
+        raise HTTPException(status_code=400, detail="Invalid mobile redirect URI")
+
+    code = secrets.token_urlsafe(32)
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=MOBILE_AUTH_CODE_EXPIRE_SECONDS
+    )
+    db.add(
+        MobileAuthCode(
+            user_id=current_user.id,
+            code_hash=hash_mobile_auth_code(code),
+            redirect_uri=redirect_uri,
+            state=payload.state,
+            expires_at=expires_at,
+        )
+    )
+    await db.commit()
+
+    callback_params = {"code": code}
+    if payload.state:
+        callback_params["state"] = payload.state
+
+    return {
+        "code": code,
+        "expires_in": MOBILE_AUTH_CODE_EXPIRE_SECONDS,
+        "redirect_url": f"{redirect_uri}?{urlencode(callback_params)}",
+    }
+
+
+@router.post("/mobile-token")
+async def exchange_mobile_auth_code(
+    payload: MobileAuthTokenExchange,
+    db: AsyncSession = Depends(get_db),
+):
+    code = payload.code.strip()
+    if not code:
+        raise HTTPException(status_code=400, detail="Invalid mobile auth code")
+
+    result = await db.execute(
+        select(MobileAuthCode).where(
+            MobileAuthCode.code_hash == hash_mobile_auth_code(code)
+        )
+    )
+    auth_code = result.scalars().first()
+
+    if (
+        not auth_code
+        or auth_code.used_at is not None
+        or mobile_auth_code_expired(auth_code.expires_at)
+    ):
+        raise HTTPException(status_code=400, detail="Invalid or expired mobile auth code")
+
+    user = await db.get(User, auth_code.user_id)
+    if not user:
+        raise HTTPException(status_code=400, detail="Invalid or expired mobile auth code")
+
+    access_token = create_access_token(user)
+    auth_code.used_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    return {
+        "access_token": access_token,
+        "user": user_to_dict(user),
+    }
 
 
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,9 +1,12 @@
 import io
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 
 from fastapi.testclient import TestClient
 from PIL import Image
 
+from app.models.mobile_auth_code import MobileAuthCode
 from app.main import app
 from app.routes import auth
 
@@ -288,6 +291,177 @@ def test_login_rejects_unverified_user(monkeypatch):
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Email not verified"
+
+
+def test_create_mobile_auth_code_returns_deep_link_callback():
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    session = FakeAuthSession()
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+
+    try:
+        response = client.post(
+            "/auth/mobile-code",
+            json={
+                "redirect_uri": "toonranks://auth/callback",
+                "state": "state-123",
+            },
+        )
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["expires_in"] == auth.MOBILE_AUTH_CODE_EXPIRE_SECONDS
+    assert body["code"]
+    assert body["redirect_url"].startswith("toonranks://auth/callback?")
+
+    parsed = urlparse(body["redirect_url"])
+    params = parse_qs(parsed.query)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "toonranks://auth/callback"
+    assert params["code"] == [body["code"]]
+    assert params["state"] == ["state-123"]
+
+    assert session.committed is True
+    assert len(session.added) == 1
+    stored = session.added[0]
+    assert isinstance(stored, MobileAuthCode)
+    assert stored.user_id == 7
+    assert stored.redirect_uri == "toonranks://auth/callback"
+    assert stored.state == "state-123"
+    assert stored.code_hash == auth.hash_mobile_auth_code(body["code"])
+    assert stored.code_hash != body["code"]
+
+
+def test_create_mobile_auth_code_rejects_unknown_redirect_uri():
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    session = FakeAuthSession()
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+
+    try:
+        response = client.post(
+            "/auth/mobile-code",
+            json={
+                "redirect_uri": "https://evil.example/callback",
+                "state": "state-123",
+            },
+        )
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid mobile redirect URI"
+    assert session.added == []
+    assert session.committed is False
+
+
+def test_exchange_mobile_auth_code_returns_token_and_marks_code_used(monkeypatch):
+    auth_code = SimpleNamespace(
+        user_id=7,
+        code_hash=auth.hash_mobile_auth_code("mobile-code"),
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used_at=None,
+    )
+    db_user = SimpleNamespace(
+        id=7,
+        username="reader",
+        role="CONTRIBUTOR",
+        avatar_url="https://cdn.example.com/avatar.webp",
+        avatar_preset="emerald",
+    )
+    session = FakeAuthSession(
+        execute_result=FakeExecuteResult(one=auth_code),
+        get_result=db_user,
+    )
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(auth, "create_access_token", lambda user: f"token-for-{user.username}")
+
+    try:
+        response = client.post("/auth/mobile-token", json={"code": "mobile-code"})
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "token-for-reader",
+        "user": {
+            "id": 7,
+            "username": "reader",
+            "role": "CONTRIBUTOR",
+            "avatar_url": "https://cdn.example.com/avatar.webp",
+            "avatar_preset": "emerald",
+        },
+    }
+    assert auth_code.used_at is not None
+    assert session.committed is True
+
+
+def test_exchange_mobile_auth_code_rejects_reused_code(monkeypatch):
+    auth_code = SimpleNamespace(
+        user_id=7,
+        code_hash=auth.hash_mobile_auth_code("mobile-code"),
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used_at=datetime.now(timezone.utc),
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=auth_code))
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(
+        auth,
+        "create_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token created")),
+    )
+
+    try:
+        response = client.post("/auth/mobile-token", json={"code": "mobile-code"})
+    finally:
+        cleanup()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid or expired mobile auth code"
+    assert session.committed is False
+
+
+def test_exchange_mobile_auth_code_rejects_expired_code(monkeypatch):
+    auth_code = SimpleNamespace(
+        user_id=7,
+        code_hash=auth.hash_mobile_auth_code("mobile-code"),
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        used_at=None,
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=auth_code))
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(
+        auth,
+        "create_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token created")),
+    )
+
+    try:
+        response = client.post("/auth/mobile-token", json={"code": "mobile-code"})
+    finally:
+        cleanup()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid or expired mobile auth code"
+    assert auth_code.used_at is None
+    assert session.committed is False
+
+
+def test_exchange_mobile_auth_code_rejects_unknown_code():
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=None))
+    cleanup = override_auth_db(session)
+
+    try:
+        response = client.post("/auth/mobile-token", json={"code": "missing-code"})
+    finally:
+        cleanup()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid or expired mobile auth code"
+    assert session.committed is False
 
 
 def test_normalize_avatar_image_returns_square_webp():

--- a/tests/db_integration_test.py
+++ b/tests/db_integration_test.py
@@ -19,6 +19,7 @@ MODEL_MODULES = [
     "app.models.forum_media_model",
     "app.models.forum_model",
     "app.models.issue",
+    "app.models.mobile_auth_code",
     "app.models.reading_list",
     "app.models.series_detail",
     "app.models.series_model",


### PR DESCRIPTION
## Summary
- Add short-lived mobile auth code storage
- Add /auth/mobile-code and /auth/mobile-token endpoints
- Return the normal Toon Ranks JWT/user shape after mobile code exchange
- Cover redirect validation, exchange success, reused codes, expired codes, and unknown codes

## Verification
- .\.venv\Scripts\python.exe -m pytest tests\auth_test.py
- .\.venv\Scripts\python.exe -m ruff check .
- .\.venv\Scripts\python.exe -m compileall app tests
- .\.venv\Scripts\python.exe -m pytest
- git diff --check