### PR TITLE
Add forum upvote and downvote backend support

### DIFF
--- a/FORUM_VOTES_MIGRATION.sql
+++ b/FORUM_VOTES_MIGRATION.sql
@@ -1,0 +1,30 @@
+-- Toon Ranks forum vote migration.
+-- Run this once before deploying the backend that exposes upvote/downvote fields.
+
+ALTER TABLE man_review.forum_posts
+  ADD COLUMN IF NOT EXISTS upvote_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS downvote_count integer NOT NULL DEFAULT 0;
+
+UPDATE man_review.forum_reactions
+SET kind = 'UPVOTE'
+WHERE kind = 'HEART';
+
+UPDATE man_review.forum_posts post
+SET
+  upvote_count = counts.upvotes,
+  downvote_count = counts.downvotes,
+  heart_count = counts.upvotes
+FROM (
+  SELECT
+    post.id AS post_id,
+    COUNT(reaction.id) FILTER (WHERE reaction.kind = 'UPVOTE') AS upvotes,
+    COUNT(reaction.id) FILTER (WHERE reaction.kind = 'DOWNVOTE') AS downvotes
+  FROM man_review.forum_posts post
+  LEFT JOIN man_review.forum_reactions reaction
+    ON reaction.post_id = post.id
+  GROUP BY post.id
+) counts
+WHERE post.id = counts.post_id;
+
+ALTER TABLE man_review.forum_reactions
+  ALTER COLUMN kind SET DEFAULT 'UPVOTE';

--- a/app/models/forum_model.py
+++ b/app/models/forum_model.py
@@ -88,7 +88,11 @@ class ForumPost(Base):
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    # Legacy heart_count is kept during the web/mobile transition. New clients
+    # should use upvote_count/downvote_count and ForumReaction.kind.
     heart_count = Column(Integer, nullable=False, server_default="0")
+    upvote_count = Column(Integer, nullable=False, server_default="0")
+    downvote_count = Column(Integer, nullable=False, server_default="0")
 
     # relationships
     thread = relationship("ForumThread", back_populates="posts")
@@ -160,6 +164,6 @@ class ForumReaction(Base):
         nullable=False,
         index=True,
     )
-    # single MVP reaction type ("HEART"), keep extensible
-    kind = Column(String(20), nullable=False, server_default="HEART")
+    # Valid values: UPVOTE, DOWNVOTE. Legacy HEART rows should be migrated to UPVOTE.
+    kind = Column(String(20), nullable=False, server_default="UPVOTE")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/routes/forum_routes.py
+++ b/app/routes/forum_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response,
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, delete
-from typing import Optional, List
+from typing import Literal, Optional, List
 
 from app.database import get_async_session
 from app.models.forum_model import ForumThread, ForumPost, ForumSeriesRef, ForumReaction
@@ -25,32 +25,70 @@ from app.moderation.profanity import ensure_clean
 
 router = APIRouter(prefix="/forum", tags=["forum"])
 DEFAULT_AVATAR_PRESET = "blue"
+UPVOTE = "UPVOTE"
+DOWNVOTE = "DOWNVOTE"
+LEGACY_HEART = "HEART"
+POSITIVE_REACTION_KINDS = (UPVOTE, LEGACY_HEART)
 
 
 class LockToggleIn(BaseModel):
     locked: bool
+
+class ForumVoteIn(BaseModel):
+    vote: Optional[Literal["UPVOTE", "DOWNVOTE"]] = None
+
+
+class ForumVoteOut(BaseModel):
+    viewer_vote: Optional[Literal["UPVOTE", "DOWNVOTE"]] = None
+    upvote_count: int
+    downvote_count: int
+
 
 class HeartToggleOut(BaseModel):
     hearted: bool
     count: int
 
 
-async def _post_heart_bits(db: AsyncSession, post_id: int, viewer_id: Optional[int]) -> tuple[int, bool]:
-    # count hearts
-    count_stmt = select(func.count(ForumReaction.id)).where(
-        ForumReaction.post_id == post_id, ForumReaction.kind == "HEART"
-    )
-    heart_count = int((await db.execute(count_stmt)).scalar_one() or 0)
+def _normalize_vote_kind(kind: Optional[str]) -> Optional[str]:
+    if kind == LEGACY_HEART:
+        return UPVOTE
+    if kind in {UPVOTE, DOWNVOTE}:
+        return kind
+    return None
 
-    has = False
+
+async def _post_vote_bits(
+    db: AsyncSession, post_id: int, viewer_id: Optional[int]
+) -> tuple[int, int, Optional[str]]:
+    upvote_stmt = select(func.count(ForumReaction.id)).where(
+        ForumReaction.post_id == post_id, ForumReaction.kind.in_(POSITIVE_REACTION_KINDS)
+    )
+    upvote_count = int((await db.execute(upvote_stmt)).scalar_one() or 0)
+
+    downvote_stmt = select(func.count(ForumReaction.id)).where(
+        ForumReaction.post_id == post_id, ForumReaction.kind == DOWNVOTE
+    )
+    downvote_count = int((await db.execute(downvote_stmt)).scalar_one() or 0)
+
+    viewer_vote = None
     if viewer_id:
-        has_stmt = select(func.count(ForumReaction.id)).where(
-            ForumReaction.post_id == post_id,
-            ForumReaction.user_id == viewer_id,
-            ForumReaction.kind == "HEART",
+        viewer_stmt = (
+            select(ForumReaction)
+            .where(
+                ForumReaction.post_id == post_id,
+                ForumReaction.user_id == viewer_id,
+            )
+            .limit(1)
         )
-        has = (await db.execute(has_stmt)).scalar_one() > 0
-    return heart_count, has
+        reaction = (await db.execute(viewer_stmt)).scalars().first()
+        viewer_vote = _normalize_vote_kind(getattr(reaction, "kind", None))
+
+    return upvote_count, downvote_count, viewer_vote
+
+
+async def _post_heart_bits(db: AsyncSession, post_id: int, viewer_id: Optional[int]) -> tuple[int, bool]:
+    upvote_count, _downvote_count, viewer_vote = await _post_vote_bits(db, post_id, viewer_id)
+    return upvote_count, viewer_vote == UPVOTE
 
 
 # ------------------------------
@@ -91,10 +129,13 @@ async def _post_to_plain_dict(p: ForumPost, db: AsyncSession, viewer: Optional["
     if p.author_id:
         author = await db.get(User, p.author_id)
 
-    heart_count, viewer_has = await _post_heart_bits(db, p.id, getattr(viewer, "id", None))
+    upvote_count, downvote_count, viewer_vote = await _post_vote_bits(
+        db, p.id, getattr(viewer, "id", None)
+    )
     author_profile = _author_profile(author)
 
     # Always include parent_id; use 0 for top-level
+    resolved_upvotes = int(getattr(p, "upvote_count", upvote_count) or upvote_count)
     return {
         "id": p.id,
         **author_profile,
@@ -103,8 +144,11 @@ async def _post_to_plain_dict(p: ForumPost, db: AsyncSession, viewer: Optional["
         "updated_at": str(p.updated_at),
         "series_refs": srefs,
         "parent_id": int(p.parent_id) if p.parent_id is not None else 0,
-        "heart_count": int(getattr(p, "heart_count", heart_count) or heart_count),
-        "viewer_has_hearted": bool(viewer_has),
+        "upvote_count": resolved_upvotes,
+        "downvote_count": int(getattr(p, "downvote_count", downvote_count) or downvote_count),
+        "viewer_vote": viewer_vote,
+        "heart_count": resolved_upvotes,
+        "viewer_has_hearted": viewer_vote == UPVOTE,
     }
 
 def dump_model(m):
@@ -190,7 +234,10 @@ async def _post_to_out(p: ForumPost, db: AsyncSession, viewer: Optional["User"]=
     if p.author_id:
         author = await db.get(User, p.author_id)
 
-    heart_count, viewer_has = await _post_heart_bits(db, p.id, getattr(viewer, "id", None))
+    upvote_count, downvote_count, viewer_vote = await _post_vote_bits(
+        db, p.id, getattr(viewer, "id", None)
+    )
+    resolved_upvotes = int(getattr(p, "upvote_count", upvote_count) or upvote_count)
 
     return ForumPostOut(
         id=p.id,
@@ -200,8 +247,11 @@ async def _post_to_out(p: ForumPost, db: AsyncSession, viewer: Optional["User"]=
         updated_at=str(p.updated_at),
         series_refs=srefs,
         parent_id=p.parent_id if p.parent_id is not None else 0,
-        heart_count=int(getattr(p, "heart_count", heart_count) or heart_count),
-        viewer_has_hearted=bool(viewer_has),
+        upvote_count=resolved_upvotes,
+        downvote_count=int(getattr(p, "downvote_count", downvote_count) or downvote_count),
+        viewer_vote=viewer_vote,
+        heart_count=resolved_upvotes,
+        viewer_has_hearted=viewer_vote == UPVOTE,
     )
 
 # ------------------------------
@@ -909,6 +959,30 @@ async def toggle_heart(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    vote_result = await set_post_vote(
+        request=request,
+        thread_id=thread_id,
+        post_id=post_id,
+        payload=ForumVoteIn(vote=UPVOTE),
+        user=user,
+        db=db,
+    )
+    return HeartToggleOut(
+        hearted=vote_result.viewer_vote == UPVOTE,
+        count=vote_result.upvote_count,
+    )
+
+
+@router.post("/threads/{thread_id}/posts/{post_id}/vote", response_model=ForumVoteOut)
+@limiter.limit("30/minute;1000/day")
+async def set_post_vote(
+    request: Request,
+    thread_id: int,
+    post_id: int,
+    payload: ForumVoteIn,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
     post = await db.get(ForumPost, post_id)
     if not post or post.thread_id != thread_id:
         raise HTTPException(status_code=404, detail="Post not found")
@@ -921,37 +995,47 @@ async def toggle_heart(
             .where(
                 ForumReaction.post_id == post_id,
                 ForumReaction.user_id == user.id,
-                ForumReaction.kind == "HEART",
             )
             .limit(1)
         )
     ).scalars().first()
 
-    if existing:
-        # remove
-        await db.delete(existing)
-        # denorm
-        if hasattr(post, "heart_count") and post.heart_count is not None:
-            post.heart_count = max(0, int(post.heart_count) - 1)
-        await db.commit()
-        # count
-        count_stmt = select(func.count(ForumReaction.id)).where(
-            ForumReaction.post_id == post_id, ForumReaction.kind == "HEART"
-        )
-        count = int((await db.execute(count_stmt)).scalar_one() or 0)
-        return HeartToggleOut(hearted=False, count=count)
-    else:
-        # add
-        db.add(ForumReaction(post_id=post_id, user_id=user.id, kind="HEART"))
-        # denorm
-        if hasattr(post, "heart_count") and post.heart_count is not None:
-            post.heart_count = int(post.heart_count) + 1
-        await db.commit()
-        count_stmt = select(func.count(ForumReaction.id)).where(
-            ForumReaction.post_id == post_id, ForumReaction.kind == "HEART"
-        )
-        count = int((await db.execute(count_stmt)).scalar_one() or 0)
-        return HeartToggleOut(hearted=True, count=count)
+    requested_vote = payload.vote
+    existing_vote = _normalize_vote_kind(getattr(existing, "kind", None))
 
+    if requested_vote is None or existing_vote == requested_vote:
+        viewer_vote = None
+        if existing:
+            await db.delete(existing)
+    elif existing:
+        existing.kind = requested_vote
+        viewer_vote = requested_vote
+    else:
+        db.add(ForumReaction(post_id=post_id, user_id=user.id, kind=requested_vote))
+        viewer_vote = requested_vote
+
+    upvote_count = int(getattr(post, "upvote_count", 0) or 0)
+    downvote_count = int(getattr(post, "downvote_count", 0) or 0)
+
+    if existing_vote == UPVOTE:
+        upvote_count = max(0, upvote_count - 1)
+    elif existing_vote == DOWNVOTE:
+        downvote_count = max(0, downvote_count - 1)
+
+    if viewer_vote == UPVOTE:
+        upvote_count += 1
+    elif viewer_vote == DOWNVOTE:
+        downvote_count += 1
+
+    post.upvote_count = upvote_count
+    post.downvote_count = downvote_count
+    post.heart_count = upvote_count
+    await db.commit()
+
+    return ForumVoteOut(
+        viewer_vote=viewer_vote,
+        upvote_count=upvote_count,
+        downvote_count=downvote_count,
+    )
 
 

--- a/app/schemas/forum_schemas.py
+++ b/app/schemas/forum_schemas.py
@@ -23,6 +23,9 @@ class ForumPostOut(BaseModel):
     updated_at: str
     series_refs: List[SeriesRefOut] = []
     parent_id: Optional[int] = None
+    upvote_count: int = 0
+    downvote_count: int = 0
+    viewer_vote: Optional[str] = None
     heart_count: int = 0
     viewer_has_hearted: bool = False
 

--- a/tests/forum_routes_test.py
+++ b/tests/forum_routes_test.py
@@ -94,6 +94,10 @@ class FakeForumSession:
             item.latest_first = False
         if hasattr(item, "heart_count") and item.heart_count is None:
             item.heart_count = 0
+        if hasattr(item, "upvote_count") and item.upvote_count is None:
+            item.upvote_count = 0
+        if hasattr(item, "downvote_count") and item.downvote_count is None:
+            item.downvote_count = 0
 
 
 def thread_object(**overrides):
@@ -122,6 +126,8 @@ def post_object(**overrides):
         "created_at": NOW,
         "updated_at": NOW,
         "heart_count": 0,
+        "upvote_count": 0,
+        "downvote_count": 0,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -246,6 +252,7 @@ def test_create_post_returns_author_avatar_metadata():
         results=[
             FakeExecuteResult(rows=[]),
             FakeExecuteResult(scalar_one=0),
+            FakeExecuteResult(scalar_one=0),
         ],
         get_results={
             (ForumThread, 1): thread_object(),
@@ -293,13 +300,102 @@ def test_delete_thread_rejects_non_owner_non_admin_user():
     assert session.committed is False
 
 
-def test_toggle_heart_adds_reaction_and_returns_count():
-    post = post_object(heart_count=0)
+def test_set_post_vote_adds_upvote_and_returns_counts():
+    post = post_object(upvote_count=0, downvote_count=0, heart_count=0)
     session = FakeForumSession(
-        results=[
-            FakeExecuteResult(first=None),
-            FakeExecuteResult(scalar_one=1),
-        ],
+        results=[FakeExecuteResult(first=None)],
+        get_results={(ForumPost, 5): post},
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads/1/posts/5/vote",
+            json={"vote": "UPVOTE"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "viewer_vote": "UPVOTE",
+        "upvote_count": 1,
+        "downvote_count": 0,
+    }
+    assert session.committed is True
+    assert len(session.added) == 1
+    assert isinstance(session.added[0], ForumReaction)
+    assert session.added[0].post_id == 5
+    assert session.added[0].user_id == 10
+    assert session.added[0].kind == "UPVOTE"
+    assert post.upvote_count == 1
+    assert post.downvote_count == 0
+    assert post.heart_count == 1
+
+
+def test_set_post_vote_switches_upvote_to_downvote():
+    post = post_object(upvote_count=1, downvote_count=0, heart_count=1)
+    existing = ForumReaction(post_id=5, user_id=10, kind="UPVOTE")
+    session = FakeForumSession(
+        results=[FakeExecuteResult(first=existing)],
+        get_results={(ForumPost, 5): post},
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads/1/posts/5/vote",
+            json={"vote": "DOWNVOTE"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "viewer_vote": "DOWNVOTE",
+        "upvote_count": 0,
+        "downvote_count": 1,
+    }
+    assert existing.kind == "DOWNVOTE"
+    assert session.deleted == []
+    assert post.upvote_count == 0
+    assert post.downvote_count == 1
+    assert post.heart_count == 0
+
+
+def test_set_post_vote_toggles_same_vote_off():
+    post = post_object(upvote_count=1, downvote_count=0, heart_count=1)
+    existing = ForumReaction(post_id=5, user_id=10, kind="UPVOTE")
+    session = FakeForumSession(
+        results=[FakeExecuteResult(first=existing)],
+        get_results={(ForumPost, 5): post},
+    )
+    cleanup = override_forum_dependencies(session)
+
+    try:
+        response = client.post(
+            "/forum/threads/1/posts/5/vote",
+            json={"vote": "UPVOTE"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "viewer_vote": None,
+        "upvote_count": 0,
+        "downvote_count": 0,
+    }
+    assert session.deleted == [existing]
+    assert post.upvote_count == 0
+    assert post.downvote_count == 0
+    assert post.heart_count == 0
+
+
+def test_toggle_heart_compatibility_maps_to_upvote():
+    post = post_object(upvote_count=0, downvote_count=0, heart_count=0)
+    session = FakeForumSession(
+        results=[FakeExecuteResult(first=None)],
         get_results={(ForumPost, 5): post},
     )
     cleanup = override_forum_dependencies(session)
@@ -311,9 +407,3 @@ def test_toggle_heart_adds_reaction_and_returns_count():
 
     assert response.status_code == 200
     assert response.json() == {"hearted": True, "count": 1}
-    assert session.committed is True
-    assert len(session.added) == 1
-    assert isinstance(session.added[0], ForumReaction)
-    assert session.added[0].post_id == 5
-    assert session.added[0].user_id == 10
-    assert post.heart_count == 1


### PR DESCRIPTION
## Summary
- Adds real forum post voting with UPVOTE and DOWNVOTE reactions
- Exposes upvote_count, downvote_count, and viewer_vote on forum posts
- Adds a new /vote endpoint while keeping /heart as a temporary compatibility shim
- Includes migration SQL to backfill existing HEART reactions as UPVOTE

## Verification
- .\.venv\Scripts\python.exe -m pytest tests\forum_routes_test.py
- .\.venv\Scripts\python.exe -m ruff check app tests
- .\.venv\Scripts\python.exe -m compileall app tests
- .\.venv\Scripts\python.exe -m pytest