### PR TITLE
Clarify verification email spam guidance

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -48,8 +48,10 @@ Welcome to Toon Ranks. Verify your email address to finish setting up your reade
 
 {verify_url}
 
-This link expires in 1 hour. If you have questions, reply to this email
-or contact {SUPPORT_EMAIL}.
+This link expires in 1 hour. If future Toon Ranks emails land in your Spam folder,
+mark them as Not Spam so verification and support messages arrive normally.
+
+If you have questions, reply to this email or contact {SUPPORT_EMAIL}.
 
 If you did not create a Toon Ranks account, you can safely ignore this email.
 
@@ -105,7 +107,7 @@ The Toon Ranks team
                 <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin:26px 0 0;border:1px solid #e7edf5;border-radius:16px;background:#f8fbff;">
                   <tr>
                     <td style="padding:16px 18px;color:#5d6878;font-size:13px;line-height:21px;">
-                      This verification link expires in 1 hour. If the request was not yours, you can ignore this message and the account will remain unverified.
+                      This verification link expires in 1 hour. If this email landed in Spam, mark it as Not Spam before using the link so future Toon Ranks messages arrive normally.
                     </td>
                   </tr>
                 </table>
@@ -140,6 +142,9 @@ The Toon Ranks team
                 </p>
                 <p style="margin:16px 0 0;">
                   This verification link expires in 1 hour. If you did not create a Toon Ranks account, no action is needed.
+                </p>
+                <p style="margin:16px 0 0;">
+                  If this message was filtered to Spam, mark it as Not Spam to help your inbox recognize Toon Ranks.
                 </p>
               </td>
             </tr>

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -229,7 +229,10 @@ async def signup(request: Request, user: UserCreate, db: AsyncSession = Depends(
         raise HTTPException(status_code=500, detail="Signup failed during email sending")
 
     return SignupResponse(
-        message="User created successfully. Please verify your email.",
+        message=(
+            "User created successfully. Please check your inbox and Spam folder "
+            "for the verification email."
+        ),
         token=token,
     )
 
@@ -452,7 +455,12 @@ async def resend_verification(
         # Don’t leak details; stay generic
         return {"message": "If an account exists, a new verification link has been sent."}
 
-    return {"message": "Verification email sent. Please check your inbox."}
+    return {
+        "message": (
+            "Verification email sent. Please check your inbox and Spam folder. "
+            "If it lands in Spam, mark it as Not Spam."
+        )
+    }
 
 
 @router.get("/users", response_model=list[UserAdminOut])

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -126,7 +126,10 @@ def test_signup_creates_unverified_user_with_normalized_email(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {
-        "message": "User created successfully. Please verify your email.",
+        "message": (
+            "User created successfully. Please check your inbox and Spam folder "
+            "for the verification email."
+        ),
         "token": "token-for-reader@gmail.com",
     }
     assert session.flushed is True

--- a/tests/email_service_test.py
+++ b/tests/email_service_test.py
@@ -34,10 +34,12 @@ def test_build_verification_email_includes_plain_text_and_html_parts(monkeypatch
     assert "https://www.toonranks.com/verify-email?token=test-token" in body
     assert "The Toon Ranks team" in body
     assert "This link expires in 1 hour." in body
+    assert "mark them as Not Spam" in body
     assert "TOON RANKS" in html
     assert "Confirm your Toon Ranks email" in html
     assert "Confirm email" in html
     assert "saved series, category ratings, and forum discussions" in html
+    assert "mark it as Not Spam" in html
     assert "The Toon Ranks team" in html
     assert "Nofara LLC" in html
     assert "support@toonranks.com" in html


### PR DESCRIPTION
## Summary
- Add Spam and Not Spam guidance to the verification email plain-text and HTML copy.
- Update signup and resend verification API messages to tell users to check inbox and Spam.
- Update auth and email-service tests for the revised copy.