### PR TITLE
Add forgot password backend flow

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -176,18 +176,165 @@ The Toon Ranks team
     return msg
 
 
-def send_verification_email(to_email: str, token: str):
+def _build_password_reset_email(to_email: str, token: str) -> EmailMessage:
+    from_email = _required_env("FROM_EMAIL")
+
+    reset_url = f"{SITE_ORIGIN}/reset-password?token={token}"
+    subject = "Reset your Toon Ranks password"
+    escaped_reset_url = escape(reset_url, quote=True)
+    escaped_logo_url = escape(LOGO_URL, quote=True)
+
+    text = f"""Hi there,
+
+We received a request to reset your Toon Ranks password.
+
+{reset_url}
+
+This link expires in 30 minutes. If you did not request a password reset, you can
+safely ignore this email and your password will stay the same.
+
+Thanks,
+The Toon Ranks team
+"""
+
+    html = f"""\
+<!doctype html>
+<html>
+  <body style="margin:0;background:#ffffff;font-family:Arial,Helvetica,sans-serif;color:#34364a;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">
+      Reset your Toon Ranks password. This link expires in 30 minutes.
+    </div>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#ffffff;">
+      <tr>
+        <td align="center" style="padding:64px 20px 40px;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:440px;">
+            <tr>
+              <td align="center" style="padding:0 0 28px;">
+                <table role="presentation" cellspacing="0" cellpadding="0" style="border:1px solid #e7edf5;border-radius:18px;background:#ffffff;box-shadow:0 10px 24px rgba(15,23,42,0.05);">
+                  <tr>
+                    <td style="padding:10px 16px 10px 12px;">
+                      <table role="presentation" cellspacing="0" cellpadding="0">
+                        <tr>
+                          <td style="vertical-align:middle;">
+                            <img src="{escaped_logo_url}" width="42" height="42" alt="" style="display:block;border-radius:12px;border:0;">
+                          </td>
+                          <td style="vertical-align:middle;padding-left:12px;font-size:13px;line-height:18px;font-weight:800;letter-spacing:2.8px;color:#182235;">
+                            TOON RANKS
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td align="left">
+                <div style="margin:0 0 18px;width:54px;height:4px;background:#74c7f7;border-radius:999px;"></div>
+                <h1 style="margin:0;color:#243044;font-size:30px;line-height:38px;font-weight:700;letter-spacing:0;">
+                  Reset your password
+                </h1>
+                <p style="margin:16px 0 0;color:#556074;font-size:15px;line-height:24px;">
+                  Use the button below to choose a new password for your Toon Ranks account.
+                </p>
+                <p style="margin:22px 0 0;">
+                  <a href="{escaped_reset_url}" style="display:inline-block;background:#1f8bd6;color:#ffffff;text-decoration:none;font-size:14px;line-height:20px;font-weight:700;padding:13px 26px;border-radius:12px;">
+                    Reset password
+                  </a>
+                </p>
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin:26px 0 0;border:1px solid #e7edf5;border-radius:16px;background:#f8fbff;">
+                  <tr>
+                    <td style="padding:16px 18px;color:#5d6878;font-size:13px;line-height:21px;">
+                      This reset link expires in 30 minutes. If you did not request it, you can ignore this email and your password will stay the same.
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:22px 0 0;color:#556074;font-size:14px;line-height:22px;">
+                  Questions or trouble signing in? Reply here and we will help.
+                </p>
+                <p style="margin:24px 0 0;color:#556074;font-size:14px;line-height:22px;">
+                  Thanks,<br>
+                  <em>The Toon Ranks team</em>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:26px 0 0;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                  <tr>
+                    <td style="border-top:1px solid #eef0f6;font-size:1px;line-height:1px;">&nbsp;</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td align="left" style="padding:18px 0 0;color:#8792a3;font-size:12px;line-height:20px;">
+                <p style="margin:0;">
+                  Sent with care from<br>
+                  Toon Ranks by {escape(OPERATOR_NAME)}<br>
+                  <a href="{escape(SITE_ORIGIN, quote=True)}" style="color:#68778a;text-decoration:none;">toonranks.com</a>
+                </p>
+                <p style="margin:16px 0 0;">
+                  Need help? Reply to this email or contact
+                  <a href="mailto:{escape(SUPPORT_EMAIL, quote=True)}" style="color:#68778a;text-decoration:underline;">{escape(SUPPORT_EMAIL)}</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 0 0;">
+                <p style="margin:0;word-break:break-all;color:#9aa4b5;font-size:11px;line-height:18px;">
+                  Button not working? Paste this link into your browser:<br>
+                  <a href="{escaped_reset_url}" style="color:#68778a;">{escaped_reset_url}</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+"""
+
+    msg = EmailMessage()
+    msg["From"] = formataddr((FROM_NAME, from_email))
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg["Reply-To"] = from_email
+    msg["Message-ID"] = make_msgid(domain=_message_id_domain(from_email))
+    msg["X-Auto-Response-Suppress"] = "All"
+    msg.set_content(text)
+    msg.add_alternative(html, subtype="html")
+    return msg
+
+
+def _send_email(to_email: str, msg: EmailMessage):
     smtp_host = _required_env("SMTP_HOST")
     smtp_username = _required_env("SMTP_USERNAME")
     smtp_password = _required_env("SMTP_PASSWORD")
     from_email = _required_env("FROM_EMAIL")
+
+    with smtplib.SMTP(smtp_host, _smtp_port()) as server:
+        server.starttls()
+        server.login(smtp_username, smtp_password)
+        server.send_message(msg, from_addr=from_email, to_addrs=[to_email])
+
+
+def send_verification_email(to_email: str, token: str):
     msg = _build_verification_email(to_email, token)
 
     try:
-        with smtplib.SMTP(smtp_host, _smtp_port()) as server:
-            server.starttls()
-            server.login(smtp_username, smtp_password)
-            server.send_message(msg, from_addr=from_email, to_addrs=[to_email])
+        _send_email(to_email, msg)
+    except Exception as e:
+        print("SMTP send failed:", e)
+        raise
+
+
+def send_password_reset_email(to_email: str, token: str):
+    msg = _build_password_reset_email(to_email, token)
+
+    try:
+        _send_email(to_email, msg)
     except Exception as e:
         print("SMTP send failed:", e)
         raise

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -3,12 +3,14 @@ from fastapi import (APIRouter, Depends, HTTPException,
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import AsyncSessionLocal
-from app.email_service import send_verification_email
+from app.email_service import send_password_reset_email, send_verification_email
 from app.limiter import limiter
 from app.models.user_model import User
 from app.schemas.user_schemas import (
     AvatarPresetUpdate,
+    ForgotPasswordRequest,
     ResendVerification,
+    ResetPasswordRequest,
     SignupResponse,
     UserAdminOut,
     UserAvatarOut,
@@ -27,7 +29,12 @@ from pydantic import BaseModel
 from app.models.mobile_auth_code import MobileAuthCode
 from app.utils.captcha import verify_captcha
 from app.utils.token_utils import create_access_token, get_current_user
-from app.utils.email_token_utils import verify_email_token, generate_email_token
+from app.utils.email_token_utils import (
+    generate_email_token,
+    generate_password_reset_token,
+    verify_email_token,
+    verify_password_reset_token,
+)
 from google.oauth2 import id_token
 from google.auth.transport import requests
 from datetime import datetime, timedelta, timezone
@@ -52,6 +59,9 @@ MAX_AVATAR_BYTES = 5 * 1024 * 1024
 AVATAR_SIZE = 256
 MOBILE_AUTH_CODE_EXPIRE_SECONDS = 5 * 60
 ALLOWED_MOBILE_AUTH_REDIRECT_URIS = {"toonranks://auth/callback"}
+FORGOT_PASSWORD_MESSAGE = (
+    "If an account exists for that email, a password reset link has been sent."
+)
 
 
 class MobileAuthCodeCreate(BaseModel):
@@ -366,6 +376,63 @@ async def login(request: Request, user: UserLogin, db: AsyncSession = Depends(ge
         "access_token": access_token,
         "user": user_to_dict(db_user)
     })
+
+
+@router.post("/forgot-password")
+@limiter.limit("3/minute")
+async def forgot_password(
+    request: Request,
+    payload: ForgotPasswordRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    if payload.captcha_token:
+        try:
+            await verify_captcha(payload.captcha_token, request=request)
+        except Exception:
+            return {"message": FORGOT_PASSWORD_MESSAGE}
+
+    email = str(payload.email).strip().lower()
+    result = await db.execute(select(User).where(func.lower(User.email) == email))
+    user = result.scalar_one_or_none()
+
+    if not user:
+        return {"message": FORGOT_PASSWORD_MESSAGE}
+
+    try:
+        token = generate_password_reset_token(str(user.email), str(user.password))
+        send_password_reset_email(str(user.email), token)
+    except Exception:
+        return {"message": FORGOT_PASSWORD_MESSAGE}
+
+    return {"message": FORGOT_PASSWORD_MESSAGE}
+
+
+@router.post("/reset-password")
+@limiter.limit("5/minute")
+async def reset_password(
+    request: Request,
+    payload: ResetPasswordRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    new_password = payload.password.strip()
+    if len(new_password) < 8:
+        raise HTTPException(
+            status_code=400,
+            detail="Password must be at least 8 characters",
+        )
+
+    reset_payload = verify_password_reset_token(payload.token)
+    email = str(reset_payload["email"]).strip().lower()
+    result = await db.execute(select(User).where(func.lower(User.email) == email))
+    user = result.scalar_one_or_none()
+
+    if not user or str(user.password) != str(reset_payload["password_hash"]):
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+
+    user.password = bcrypt.hash(new_password)
+    await db.commit()
+
+    return {"message": "Password reset successful. You can now log in."}
 
 
 

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -54,3 +54,13 @@ class ResendVerification(BaseModel):
     captcha_token: Optional[str] = None
 
 
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+    captcha_token: Optional[str] = None
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    password: str
+
+

--- a/app/utils/email_token_utils.py
+++ b/app/utils/email_token_utils.py
@@ -10,16 +10,37 @@ if not SECRET_KEY:
     raise RuntimeError("SECRET_KEY is not set in environment variables")
 
 
-SALT = "email-confirmation"
+EMAIL_CONFIRMATION_SALT = "email-confirmation"
+PASSWORD_RESET_SALT = "password-reset"
 
 serializer = URLSafeTimedSerializer(SECRET_KEY)
 
 def generate_email_token(email: str) -> str:
-    return serializer.dumps(email, salt=SALT)
+    return serializer.dumps(email, salt=EMAIL_CONFIRMATION_SALT)
 
 def verify_email_token(token: str, max_age: int = 3600) -> str:
     try:
-        return serializer.loads(token, salt=SALT, max_age=max_age)
+        return serializer.loads(token, salt=EMAIL_CONFIRMATION_SALT, max_age=max_age)
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid or expired token")
+
+
+def generate_password_reset_token(email: str, password_hash: str) -> str:
+    return serializer.dumps(
+        {"email": email, "password_hash": password_hash},
+        salt=PASSWORD_RESET_SALT,
+    )
+
+
+def verify_password_reset_token(token: str, max_age: int = 1800) -> dict:
+    try:
+        payload = serializer.loads(token, salt=PASSWORD_RESET_SALT, max_age=max_age)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+
+    if not isinstance(payload, dict) or not payload.get("email") or not payload.get(
+        "password_hash"
+    ):
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+    return payload
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -296,6 +296,148 @@ def test_login_rejects_unverified_user(monkeypatch):
     assert response.json()["detail"] == "Email not verified"
 
 
+def test_forgot_password_sends_reset_email_without_revealing_account(monkeypatch):
+    db_user = SimpleNamespace(
+        email="reader@gmail.com",
+        password="current-hash",
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=db_user))
+    cleanup = override_auth_db(session)
+    sent_emails = []
+
+    monkeypatch.setattr(
+        auth,
+        "generate_password_reset_token",
+        lambda email, password_hash: f"reset-token-for-{email}-{password_hash}",
+    )
+    monkeypatch.setattr(
+        auth,
+        "send_password_reset_email",
+        lambda email, token: sent_emails.append((email, token)),
+    )
+
+    try:
+        response = client.post(
+            "/auth/forgot-password",
+            json={"email": "Reader@Gmail.com"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": auth.FORGOT_PASSWORD_MESSAGE}
+    assert sent_emails == [
+        ("reader@gmail.com", "reset-token-for-reader@gmail.com-current-hash")
+    ]
+    assert session.committed is False
+
+
+def test_forgot_password_returns_generic_message_for_unknown_email(monkeypatch):
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=None))
+    cleanup = override_auth_db(session)
+
+    monkeypatch.setattr(
+        auth,
+        "send_password_reset_email",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("email sent")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/forgot-password",
+            json={"email": "missing@gmail.com"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": auth.FORGOT_PASSWORD_MESSAGE}
+    assert session.committed is False
+
+
+def test_reset_password_updates_password_and_invalidates_token(monkeypatch):
+    db_user = SimpleNamespace(
+        email="reader@gmail.com",
+        password=auth.bcrypt.hash("old-password"),
+    )
+    old_hash = db_user.password
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=db_user))
+    cleanup = override_auth_db(session)
+
+    monkeypatch.setattr(
+        auth,
+        "verify_password_reset_token",
+        lambda token: {"email": "reader@gmail.com", "password_hash": old_hash},
+    )
+
+    try:
+        response = client.post(
+            "/auth/reset-password",
+            json={"token": "reset-token", "password": "new-password"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Password reset successful. You can now log in."}
+    assert session.committed is True
+    assert db_user.password != old_hash
+    assert auth.bcrypt.verify("new-password", db_user.password)
+
+
+def test_reset_password_rejects_reused_token_after_password_changes(monkeypatch):
+    db_user = SimpleNamespace(
+        email="reader@gmail.com",
+        password=auth.bcrypt.hash("new-password"),
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=db_user))
+    cleanup = override_auth_db(session)
+
+    monkeypatch.setattr(
+        auth,
+        "verify_password_reset_token",
+        lambda token: {
+            "email": "reader@gmail.com",
+            "password_hash": "old-password-hash",
+        },
+    )
+
+    try:
+        response = client.post(
+            "/auth/reset-password",
+            json={"token": "reset-token", "password": "another-password"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid or expired token"
+    assert session.committed is False
+
+
+def test_reset_password_rejects_short_password(monkeypatch):
+    session = FakeAuthSession()
+    cleanup = override_auth_db(session)
+
+    monkeypatch.setattr(
+        auth,
+        "verify_password_reset_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token used")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/reset-password",
+            json={"token": "reset-token", "password": "short"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Password must be at least 8 characters"
+    assert session.committed is False
+
+
 def test_create_mobile_auth_code_returns_deep_link_callback():
     current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
     session = FakeAuthSession()

--- a/tests/email_service_test.py
+++ b/tests/email_service_test.py
@@ -55,3 +55,22 @@ def test_build_verification_email_requires_from_email(monkeypatch):
         module._build_verification_email("reader@example.com", "test-token")
 
     assert str(exc_info.value) == "FROM_EMAIL is required to send verification email"
+
+
+def test_build_password_reset_email_includes_plain_text_and_html_parts(monkeypatch):
+    module = reload_email_service(monkeypatch)
+
+    message = module._build_password_reset_email("reader@example.com", "reset-token")
+    body = message.get_body(preferencelist=("plain",)).get_content()
+    html = message.get_body(preferencelist=("html",)).get_content()
+
+    assert message["From"] == "Toon Ranks <support@toonranks.com>"
+    assert message["Reply-To"] == "support@toonranks.com"
+    assert message["To"] == "reader@example.com"
+    assert message["Subject"] == "Reset your Toon Ranks password"
+    assert "https://www.toonranks.com/reset-password?token=reset-token" in body
+    assert "This link expires in 30 minutes." in body
+    assert "Reset your password" in html
+    assert "Reset password" in html
+    assert "This reset link expires in 30 minutes." in html
+    assert "https://www.toonranks.com/reset-password?token=reset-token" in html

--- a/tests/email_token_utils_test.py
+++ b/tests/email_token_utils_test.py
@@ -39,3 +39,36 @@ def test_verify_email_token_rejects_token_signed_with_different_secret(monkeypat
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "Invalid or expired token"
+
+
+def test_generate_password_reset_token_round_trips_payload(monkeypatch):
+    module = reload_email_token_utils(monkeypatch)
+
+    token = module.generate_password_reset_token("reader@example.com", "hash")
+
+    assert module.verify_password_reset_token(token) == {
+        "email": "reader@example.com",
+        "password_hash": "hash",
+    }
+
+
+def test_password_reset_token_cannot_be_used_as_email_token(monkeypatch):
+    module = reload_email_token_utils(monkeypatch)
+    token = module.generate_password_reset_token("reader@example.com", "hash")
+
+    with pytest.raises(HTTPException) as exc_info:
+        module.verify_email_token(token)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid or expired token"
+
+
+def test_email_token_cannot_be_used_as_password_reset_token(monkeypatch):
+    module = reload_email_token_utils(monkeypatch)
+    token = module.generate_email_token("reader@example.com")
+
+    with pytest.raises(HTTPException) as exc_info:
+        module.verify_password_reset_token(token)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid or expired token"


### PR DESCRIPTION
## Summary
- Add signed password reset tokens with a separate salt from email verification tokens.
- Add forgot-password and reset-password auth endpoints.
- Send a branded password reset email with a 30-minute reset link.
- Keep forgot-password responses generic to avoid account enumeration.
- Invalidate old reset links after password changes by binding tokens to the current password hash.
- Add tests for password reset tokens, reset email content, and auth reset behavior.