### PR TITLE
Route auth emails through Toon Ranks aliases

### DIFF
--- a/BACKEND_TESTING.md
+++ b/BACKEND_TESTING.md
@@ -29,7 +29,7 @@ pytest -m "not integration"
 Run integration tests locally only when you have a disposable test database ready:
 
 ```bash
-set TEST_DATABASE_URL=postgresql+asyncpg://toonranks_test:toonranks_test@localhost:5432/toonranks_test
+set TEST_DATABASE_URL=postgresql+asyncpg://<local-test-user>:<local-test-password>@localhost:5432/toonranks_test
 pytest -m integration
 ```
 
@@ -91,24 +91,28 @@ Feature-specific values may also be needed when those integrations are enabled:
 - `SMTP_PORT`
 - `SMTP_USERNAME`
 - `SMTP_PASSWORD`
-- `FROM_EMAIL`
+- `VERIFICATION_FROM_EMAIL`
+- `PASSWORD_RESET_FROM_EMAIL`
 - `FROM_NAME`
 - `EMAIL_LOGO_URL`
 - `SUPPORT_EMAIL`
+- `BILLING_EMAIL`
+- `ADMIN_ALERT_EMAIL`
 - `OPERATOR_NAME`
 - `GOOGLE_CLIENT_ID`
 - `RECAPTCHA_SECRET_KEY`
 - `RECAPTCHA_SITE_KEY`
 - `RECAPTCHA_PROJECT_ID`
 
-For the Toon Ranks support mailbox on Zoho, configure email sending with these non-secret values:
+For the Toon Ranks support mailbox, keep SMTP credentials in Railway variables/secrets. Configure
+these non-secret alias values:
 
-- `SMTP_HOST=smtp.zoho.com`
-- `SMTP_PORT=587`
-- `SMTP_USERNAME=support@toonranks.com`
-- `FROM_EMAIL=support@toonranks.com`
+- `VERIFICATION_FROM_EMAIL=noreply@toonranks.com`
+- `PASSWORD_RESET_FROM_EMAIL=accounts@toonranks.com`
 - `FROM_NAME=Toon Ranks`
 - `SUPPORT_EMAIL=support@toonranks.com`
+- `BILLING_EMAIL=billing@toonranks.com`
+- `ADMIN_ALERT_EMAIL=admin@toonranks.com`
 - `OPERATOR_NAME=Nofara LLC`
 
-Set `SMTP_PASSWORD` to the Zoho application-specific password for the support mailbox.
+Never commit concrete SMTP passwords or app passwords.

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -14,6 +14,12 @@ LOGO_URL = os.getenv(
     f"{SITE_ORIGIN}/android-chrome-192x192.png",
 )
 SUPPORT_EMAIL = os.getenv("SUPPORT_EMAIL", "support@toonranks.com")
+VERIFICATION_FROM_EMAIL = os.getenv("VERIFICATION_FROM_EMAIL")
+VERIFICATION_FROM_EMAIL = VERIFICATION_FROM_EMAIL or "noreply@toonranks.com"
+PASSWORD_RESET_FROM_EMAIL = os.getenv("PASSWORD_RESET_FROM_EMAIL")
+PASSWORD_RESET_FROM_EMAIL = PASSWORD_RESET_FROM_EMAIL or "accounts@toonranks.com"
+BILLING_EMAIL = os.getenv("BILLING_EMAIL", "billing@toonranks.com")
+ADMIN_ALERT_EMAIL = os.getenv("ADMIN_ALERT_EMAIL", "admin@toonranks.com")
 OPERATOR_NAME = os.getenv("OPERATOR_NAME", "Nofara LLC")
 
 
@@ -35,7 +41,7 @@ def _message_id_domain(from_email: str) -> str:
 
 
 def _build_verification_email(to_email: str, token: str) -> EmailMessage:
-    from_email = _required_env("FROM_EMAIL")
+    from_email = VERIFICATION_FROM_EMAIL
 
     verify_url = f"{SITE_ORIGIN}/verify-email?token={token}"
     subject = "Verify your Toon Ranks email address"
@@ -168,7 +174,7 @@ The Toon Ranks team
     msg["From"] = formataddr((FROM_NAME, from_email))
     msg["To"] = to_email
     msg["Subject"] = subject
-    msg["Reply-To"] = from_email
+    msg["Reply-To"] = SUPPORT_EMAIL
     msg["Message-ID"] = make_msgid(domain=_message_id_domain(from_email))
     msg["X-Auto-Response-Suppress"] = "All"
     msg.set_content(text)
@@ -177,7 +183,7 @@ The Toon Ranks team
 
 
 def _build_password_reset_email(to_email: str, token: str) -> EmailMessage:
-    from_email = _required_env("FROM_EMAIL")
+    from_email = PASSWORD_RESET_FROM_EMAIL
 
     reset_url = f"{SITE_ORIGIN}/reset-password?token={token}"
     subject = "Reset your Toon Ranks password"
@@ -300,7 +306,7 @@ The Toon Ranks team
     msg["From"] = formataddr((FROM_NAME, from_email))
     msg["To"] = to_email
     msg["Subject"] = subject
-    msg["Reply-To"] = from_email
+    msg["Reply-To"] = SUPPORT_EMAIL
     msg["Message-ID"] = make_msgid(domain=_message_id_domain(from_email))
     msg["X-Auto-Response-Suppress"] = "All"
     msg.set_content(text)
@@ -308,11 +314,10 @@ The Toon Ranks team
     return msg
 
 
-def _send_email(to_email: str, msg: EmailMessage):
+def _send_email(to_email: str, msg: EmailMessage, from_email: str):
     smtp_host = _required_env("SMTP_HOST")
     smtp_username = _required_env("SMTP_USERNAME")
     smtp_password = _required_env("SMTP_PASSWORD")
-    from_email = _required_env("FROM_EMAIL")
 
     with smtplib.SMTP(smtp_host, _smtp_port()) as server:
         server.starttls()
@@ -324,7 +329,7 @@ def send_verification_email(to_email: str, token: str):
     msg = _build_verification_email(to_email, token)
 
     try:
-        _send_email(to_email, msg)
+        _send_email(to_email, msg, VERIFICATION_FROM_EMAIL)
     except Exception as e:
         print("SMTP send failed:", e)
         raise
@@ -334,7 +339,7 @@ def send_password_reset_email(to_email: str, token: str):
     msg = _build_password_reset_email(to_email, token)
 
     try:
-        _send_email(to_email, msg)
+        _send_email(to_email, msg, PASSWORD_RESET_FROM_EMAIL)
     except Exception as e:
         print("SMTP send failed:", e)
         raise

--- a/docs/EMAIL_ALIASES.md
+++ b/docs/EMAIL_ALIASES.md
@@ -1,0 +1,31 @@
+# Toon Ranks Email Aliases
+
+Toon Ranks uses purpose-specific aliases so account, support, billing, and internal messages are easier to identify and route.
+
+## Current Aliases
+
+| Purpose | Alias | Backend usage |
+| --- | --- | --- |
+| Signup verification | `noreply@toonranks.com` | Sender for account verification emails. |
+| Password reset | `accounts@toonranks.com` | Sender for password reset and account recovery emails. |
+| Human support/contact | `support@toonranks.com` | Public support address and reply-to address for auth emails. |
+| Billing/subscription | `billing@toonranks.com` | Reserved for future subscription, invoice, and billing support flows. |
+| Internal/admin alerts | `admin@toonranks.com` | Reserved for future operational and admin notifications. |
+
+## Runtime Variables
+
+When configuring email in production, set the SMTP host, port, username, and password in the hosting provider's secret manager. Do not commit concrete SMTP passwords or app passwords.
+
+Use these non-secret alias values:
+
+| Variable | Value |
+| --- | --- |
+| `VERIFICATION_FROM_EMAIL` | `noreply@toonranks.com` |
+| `PASSWORD_RESET_FROM_EMAIL` | `accounts@toonranks.com` |
+| `FROM_NAME` | `Toon Ranks` |
+| `SUPPORT_EMAIL` | `support@toonranks.com` |
+| `BILLING_EMAIL` | `billing@toonranks.com` |
+| `ADMIN_ALERT_EMAIL` | `admin@toonranks.com` |
+| `OPERATOR_NAME` | `Nofara LLC` |
+
+Before switching production mail traffic, confirm the SMTP provider is authorized to send as each alias. Auth emails set `Reply-To` to `support@toonranks.com` so users can still reach a person if they need help.

--- a/tests/email_service_test.py
+++ b/tests/email_service_test.py
@@ -1,13 +1,14 @@
 import importlib
 
-import pytest
-
 import app.email_service as email_service
 
 
 def reload_email_service(monkeypatch):
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://www.toonranks.com")
-    monkeypatch.setenv("FROM_EMAIL", "support@toonranks.com")
+    monkeypatch.delenv("FROM_EMAIL", raising=False)
+    monkeypatch.setenv("VERIFICATION_FROM_EMAIL", "noreply@toonranks.com")
+    monkeypatch.setenv("PASSWORD_RESET_FROM_EMAIL", "accounts@toonranks.com")
+    monkeypatch.setenv("SUPPORT_EMAIL", "support@toonranks.com")
     monkeypatch.delenv("FROM_NAME", raising=False)
     return importlib.reload(email_service)
 
@@ -17,7 +18,7 @@ def test_build_verification_email_uses_branded_sender_and_subject(monkeypatch):
 
     message = module._build_verification_email("reader@example.com", "test-token")
 
-    assert message["From"] == "Toon Ranks <support@toonranks.com>"
+    assert message["From"] == "Toon Ranks <noreply@toonranks.com>"
     assert message["Reply-To"] == "support@toonranks.com"
     assert message["To"] == "reader@example.com"
     assert message["Subject"] == "Verify your Toon Ranks email address"
@@ -47,14 +48,16 @@ def test_build_verification_email_includes_plain_text_and_html_parts(monkeypatch
     assert "https://www.toonranks.com/verify-email?token=test-token" in html
 
 
-def test_build_verification_email_requires_from_email(monkeypatch):
+def test_build_verification_email_defaults_to_noreply_alias(monkeypatch):
     module = reload_email_service(monkeypatch)
-    monkeypatch.delenv("FROM_EMAIL")
+    monkeypatch.delenv("FROM_EMAIL", raising=False)
+    monkeypatch.delenv("VERIFICATION_FROM_EMAIL", raising=False)
+    module = importlib.reload(module)
 
-    with pytest.raises(RuntimeError) as exc_info:
-        module._build_verification_email("reader@example.com", "test-token")
+    message = module._build_verification_email("reader@example.com", "test-token")
 
-    assert str(exc_info.value) == "FROM_EMAIL is required to send verification email"
+    assert message["From"] == "Toon Ranks <noreply@toonranks.com>"
+    assert message["Reply-To"] == "support@toonranks.com"
 
 
 def test_build_password_reset_email_includes_plain_text_and_html_parts(monkeypatch):
@@ -64,7 +67,7 @@ def test_build_password_reset_email_includes_plain_text_and_html_parts(monkeypat
     body = message.get_body(preferencelist=("plain",)).get_content()
     html = message.get_body(preferencelist=("html",)).get_content()
 
-    assert message["From"] == "Toon Ranks <support@toonranks.com>"
+    assert message["From"] == "Toon Ranks <accounts@toonranks.com>"
     assert message["Reply-To"] == "support@toonranks.com"
     assert message["To"] == "reader@example.com"
     assert message["Subject"] == "Reset your Toon Ranks password"


### PR DESCRIPTION
## Summary
- Route verification emails through noreply@toonranks.com
- Route password reset emails through accounts@toonranks.com
- Keep support@toonranks.com as the reply-to address
- Document current and reserved Toon Ranks email aliases

## Verification
- .\.venv\Scripts\python.exe -m pytest tests\email_service_test.py
- .\.venv\Scripts\python.exe -m ruff check .
- .\.venv\Scripts\python.exe -m compileall app tests