### PR TITLE
Clarify support contact copy in auth emails

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -57,7 +57,7 @@ Welcome to Toon Ranks. Verify your email address to finish setting up your reade
 This link expires in 1 hour. If future Toon Ranks emails land in your Spam folder,
 mark them as Not Spam so verification and support messages arrive normally.
 
-If you have questions, reply to this email or contact {SUPPORT_EMAIL}.
+If you have questions, contact {SUPPORT_EMAIL}.
 
 If you did not create a Toon Ranks account, you can safely ignore this email.
 
@@ -118,7 +118,7 @@ The Toon Ranks team
                   </tr>
                 </table>
                 <p style="margin:22px 0 0;color:#556074;font-size:14px;line-height:22px;">
-                  Questions or trouble signing in? Reply here and we will help.
+                  Questions or trouble signing in? Contact support and we will help.
                 </p>
                 <p style="margin:24px 0 0;color:#556074;font-size:14px;line-height:22px;">
                   Thanks,<br>
@@ -143,7 +143,7 @@ The Toon Ranks team
                   <a href="{escape(SITE_ORIGIN, quote=True)}" style="color:#68778a;text-decoration:none;">toonranks.com</a>
                 </p>
                 <p style="margin:16px 0 0;">
-                  Need help? Reply to this email or contact
+                  Need help? Contact
                   <a href="mailto:{escape(SUPPORT_EMAIL, quote=True)}" style="color:#68778a;text-decoration:underline;">{escape(SUPPORT_EMAIL)}</a>.
                 </p>
                 <p style="margin:16px 0 0;">
@@ -256,7 +256,7 @@ The Toon Ranks team
                   </tr>
                 </table>
                 <p style="margin:22px 0 0;color:#556074;font-size:14px;line-height:22px;">
-                  Questions or trouble signing in? Reply here and we will help.
+                  Questions or trouble signing in? Contact support and we will help.
                 </p>
                 <p style="margin:24px 0 0;color:#556074;font-size:14px;line-height:22px;">
                   Thanks,<br>
@@ -281,7 +281,7 @@ The Toon Ranks team
                   <a href="{escape(SITE_ORIGIN, quote=True)}" style="color:#68778a;text-decoration:none;">toonranks.com</a>
                 </p>
                 <p style="margin:16px 0 0;">
-                  Need help? Reply to this email or contact
+                  Need help? Contact
                   <a href="mailto:{escape(SUPPORT_EMAIL, quote=True)}" style="color:#68778a;text-decoration:underline;">{escape(SUPPORT_EMAIL)}</a>.
                 </p>
               </td>

--- a/tests/email_service_test.py
+++ b/tests/email_service_test.py
@@ -36,6 +36,9 @@ def test_build_verification_email_includes_plain_text_and_html_parts(monkeypatch
     assert "The Toon Ranks team" in body
     assert "This link expires in 1 hour." in body
     assert "mark them as Not Spam" in body
+    assert "If you have questions, contact support@toonranks.com." in body
+    assert "reply to this email" not in body.lower()
+    assert "reply here" not in html.lower()
     assert "TOON RANKS" in html
     assert "Confirm your Toon Ranks email" in html
     assert "Confirm email" in html
@@ -76,4 +79,6 @@ def test_build_password_reset_email_includes_plain_text_and_html_parts(monkeypat
     assert "Reset your password" in html
     assert "Reset password" in html
     assert "This reset link expires in 30 minutes." in html
+    assert "reply here" not in html.lower()
+    assert "reply to this email" not in html.lower()
     assert "https://www.toonranks.com/reset-password?token=reset-token" in html


### PR DESCRIPTION
## Summary
- Remove reply-oriented wording from auth email templates now that verification uses noreply@toonranks.com
- Point users directly to support@toonranks.com for help
- Add email template assertions to prevent reply wording from returning

## Verification
- .\.venv\Scripts\python.exe -m pytest tests\email_service_test.py
- .\.venv\Scripts\python.exe -m ruff check .
- .\.venv\Scripts\python.exe -m compileall app tests