### PR TITLE
Set auth email sender display names

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -9,6 +9,12 @@ load_dotenv()
 
 SITE_ORIGIN = os.getenv("PUBLIC_ORIGIN", "https://www.toonranks.com").rstrip("/")
 FROM_NAME = os.getenv("FROM_NAME", "Toon Ranks")
+VERIFICATION_FROM_NAME = os.getenv(
+    "VERIFICATION_FROM_NAME", "Toon Ranks Verification"
+)
+PASSWORD_RESET_FROM_NAME = os.getenv(
+    "PASSWORD_RESET_FROM_NAME", "Toon Ranks Accounts"
+)
 LOGO_URL = os.getenv(
     "EMAIL_LOGO_URL",
     f"{SITE_ORIGIN}/android-chrome-192x192.png",
@@ -171,7 +177,7 @@ The Toon Ranks team
 """
 
     msg = EmailMessage()
-    msg["From"] = formataddr((FROM_NAME, from_email))
+    msg["From"] = formataddr((VERIFICATION_FROM_NAME or FROM_NAME, from_email))
     msg["To"] = to_email
     msg["Subject"] = subject
     msg["Reply-To"] = SUPPORT_EMAIL
@@ -303,7 +309,7 @@ The Toon Ranks team
 """
 
     msg = EmailMessage()
-    msg["From"] = formataddr((FROM_NAME, from_email))
+    msg["From"] = formataddr((PASSWORD_RESET_FROM_NAME or FROM_NAME, from_email))
     msg["To"] = to_email
     msg["Subject"] = subject
     msg["Reply-To"] = SUPPORT_EMAIL

--- a/tests/email_service_test.py
+++ b/tests/email_service_test.py
@@ -10,6 +10,8 @@ def reload_email_service(monkeypatch):
     monkeypatch.setenv("PASSWORD_RESET_FROM_EMAIL", "accounts@toonranks.com")
     monkeypatch.setenv("SUPPORT_EMAIL", "support@toonranks.com")
     monkeypatch.delenv("FROM_NAME", raising=False)
+    monkeypatch.delenv("VERIFICATION_FROM_NAME", raising=False)
+    monkeypatch.delenv("PASSWORD_RESET_FROM_NAME", raising=False)
     return importlib.reload(email_service)
 
 
@@ -18,7 +20,7 @@ def test_build_verification_email_uses_branded_sender_and_subject(monkeypatch):
 
     message = module._build_verification_email("reader@example.com", "test-token")
 
-    assert message["From"] == "Toon Ranks <noreply@toonranks.com>"
+    assert message["From"] == "Toon Ranks Verification <noreply@toonranks.com>"
     assert message["Reply-To"] == "support@toonranks.com"
     assert message["To"] == "reader@example.com"
     assert message["Subject"] == "Verify your Toon Ranks email address"
@@ -59,7 +61,7 @@ def test_build_verification_email_defaults_to_noreply_alias(monkeypatch):
 
     message = module._build_verification_email("reader@example.com", "test-token")
 
-    assert message["From"] == "Toon Ranks <noreply@toonranks.com>"
+    assert message["From"] == "Toon Ranks Verification <noreply@toonranks.com>"
     assert message["Reply-To"] == "support@toonranks.com"
 
 
@@ -70,7 +72,7 @@ def test_build_password_reset_email_includes_plain_text_and_html_parts(monkeypat
     body = message.get_body(preferencelist=("plain",)).get_content()
     html = message.get_body(preferencelist=("html",)).get_content()
 
-    assert message["From"] == "Toon Ranks <accounts@toonranks.com>"
+    assert message["From"] == "Toon Ranks Accounts <accounts@toonranks.com>"
     assert message["Reply-To"] == "support@toonranks.com"
     assert message["To"] == "reader@example.com"
     assert message["Subject"] == "Reset your Toon Ranks password"


### PR DESCRIPTION
## Summary
- Add separate display names for verification and password reset emails
- Keep sender aliases as noreply@toonranks.com and accounts@toonranks.com
- Update email tests to lock in the new From headers

## Verification
- .\.venv\Scripts\python.exe -m pytest tests\email_service_test.py
- .\.venv\Scripts\python.exe -m ruff check .
- .\.venv\Scripts\python.exe -m compileall app tests