### PR TITLE
Add backend mobile refresh token flow

### DIFF
--- a/app/models/mobile_refresh_token.py
+++ b/app/models/mobile_refresh_token.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class MobileRefreshToken(Base):
+    __tablename__ = "mobile_refresh_tokens"
+    __table_args__ = {"schema": "man_review"}
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("man_review.users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token_hash = Column(String(128), unique=True, nullable=False, index=True)
+    created_at = Column(DateTime(timezone=True), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    user = relationship("User")

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -27,6 +27,7 @@ from PIL import Image, ImageOps
 from pydantic import BaseModel
 
 from app.models.mobile_auth_code import MobileAuthCode
+from app.models.mobile_refresh_token import MobileRefreshToken
 from app.utils.captcha import verify_captcha
 from app.utils.token_utils import create_access_token, get_current_user
 from app.utils.email_token_utils import (
@@ -58,6 +59,7 @@ ALLOWED_AVATAR_MIMES = {"image/png", "image/jpeg", "image/webp"}
 MAX_AVATAR_BYTES = 5 * 1024 * 1024
 AVATAR_SIZE = 256
 MOBILE_AUTH_CODE_EXPIRE_SECONDS = 5 * 60
+MOBILE_REFRESH_TOKEN_EXPIRE_DAYS = 30
 ALLOWED_MOBILE_AUTH_REDIRECT_URIS = {"toonranks://auth/callback"}
 FORGOT_PASSWORD_MESSAGE = (
     "If an account exists for that email, a password reset link has been sent."
@@ -71,6 +73,15 @@ class MobileAuthCodeCreate(BaseModel):
 
 class MobileAuthTokenExchange(BaseModel):
     code: str
+
+
+class MobileRefreshTokenExchange(BaseModel):
+    refresh_token: str
+
+
+class MobileLogoutRequest(BaseModel):
+    refresh_token: Optional[str] = None
+
 
 async def get_db():
     async with AsyncSessionLocal() as session:
@@ -104,14 +115,41 @@ def hash_mobile_auth_code(code: str) -> str:
     return hashlib.sha256(code.encode("utf-8")).hexdigest()
 
 
+def hash_mobile_refresh_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
 def is_allowed_mobile_redirect_uri(redirect_uri: str) -> bool:
     return redirect_uri in ALLOWED_MOBILE_AUTH_REDIRECT_URIS
 
 
-def mobile_auth_code_expired(expires_at: datetime) -> bool:
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def timestamp_expired(expires_at: datetime) -> bool:
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
-    return expires_at <= datetime.now(timezone.utc)
+    return expires_at <= utc_now()
+
+
+def mobile_auth_code_expired(expires_at: datetime) -> bool:
+    return timestamp_expired(expires_at)
+
+
+def mobile_refresh_token_expired(expires_at: datetime) -> bool:
+    return timestamp_expired(expires_at)
+
+
+def create_mobile_refresh_token_record(user_id: int) -> tuple[str, MobileRefreshToken]:
+    token = secrets.token_urlsafe(48)
+    now = utc_now()
+    return token, MobileRefreshToken(
+        user_id=user_id,
+        token_hash=hash_mobile_refresh_token(token),
+        created_at=now,
+        expires_at=now + timedelta(days=MOBILE_REFRESH_TOKEN_EXPIRE_DAYS),
+    )
 
 
 async def get_user_for_update(current_user: User, db: AsyncSession) -> User:
@@ -132,7 +170,7 @@ async def create_mobile_auth_code(
         raise HTTPException(status_code=400, detail="Invalid mobile redirect URI")
 
     code = secrets.token_urlsafe(32)
-    expires_at = datetime.now(timezone.utc) + timedelta(
+    expires_at = utc_now() + timedelta(
         seconds=MOBILE_AUTH_CODE_EXPIRE_SECONDS
     )
     db.add(
@@ -185,13 +223,77 @@ async def exchange_mobile_auth_code(
         raise HTTPException(status_code=400, detail="Invalid or expired mobile auth code")
 
     access_token = create_access_token(user)
-    auth_code.used_at = datetime.now(timezone.utc)
+    refresh_token, refresh_token_record = create_mobile_refresh_token_record(user.id)
+    db.add(refresh_token_record)
+    auth_code.used_at = utc_now()
+    await db.commit()
+
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "user": user_to_dict(user),
+    }
+
+
+@router.post("/mobile-refresh")
+async def refresh_mobile_access_token(
+    payload: MobileRefreshTokenExchange,
+    db: AsyncSession = Depends(get_db),
+):
+    refresh_token = payload.refresh_token.strip()
+    if not refresh_token:
+        raise HTTPException(status_code=400, detail="Invalid mobile refresh token")
+
+    result = await db.execute(
+        select(MobileRefreshToken).where(
+            MobileRefreshToken.token_hash == hash_mobile_refresh_token(refresh_token)
+        )
+    )
+    token_record = result.scalars().first()
+
+    if (
+        not token_record
+        or token_record.revoked_at is not None
+        or mobile_refresh_token_expired(token_record.expires_at)
+    ):
+        raise HTTPException(status_code=401, detail="Invalid or expired mobile refresh token")
+
+    user = await db.get(User, token_record.user_id)
+    if not user:
+        token_record.revoked_at = utc_now()
+        await db.commit()
+        raise HTTPException(status_code=401, detail="Invalid or expired mobile refresh token")
+
+    token_record.last_used_at = utc_now()
+    access_token = create_access_token(user)
     await db.commit()
 
     return {
         "access_token": access_token,
         "user": user_to_dict(user),
     }
+
+
+@router.post("/mobile-logout")
+async def revoke_mobile_refresh_token(
+    payload: MobileLogoutRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    refresh_token = (payload.refresh_token or "").strip()
+    if not refresh_token:
+        return {"message": "Logged out"}
+
+    result = await db.execute(
+        select(MobileRefreshToken).where(
+            MobileRefreshToken.token_hash == hash_mobile_refresh_token(refresh_token)
+        )
+    )
+    token_record = result.scalars().first()
+    if token_record and token_record.revoked_at is None:
+        token_record.revoked_at = utc_now()
+        await db.commit()
+
+    return {"message": "Logged out"}
 
 
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from PIL import Image
 
 from app.models.mobile_auth_code import MobileAuthCode
+from app.models.mobile_refresh_token import MobileRefreshToken
 from app.main import app
 from app.routes import auth
 
@@ -503,7 +504,7 @@ def test_create_mobile_auth_code_rejects_unknown_redirect_uri():
     assert session.committed is False
 
 
-def test_exchange_mobile_auth_code_returns_token_and_marks_code_used(monkeypatch):
+def test_exchange_mobile_auth_code_returns_tokens_and_marks_code_used(monkeypatch):
     auth_code = SimpleNamespace(
         user_id=7,
         code_hash=auth.hash_mobile_auth_code("mobile-code"),
@@ -530,8 +531,10 @@ def test_exchange_mobile_auth_code_returns_token_and_marks_code_used(monkeypatch
         cleanup()
 
     assert response.status_code == 200
-    assert response.json() == {
+    body = response.json()
+    assert body == {
         "access_token": "token-for-reader",
+        "refresh_token": body["refresh_token"],
         "user": {
             "id": 7,
             "username": "reader",
@@ -540,8 +543,214 @@ def test_exchange_mobile_auth_code_returns_token_and_marks_code_used(monkeypatch
             "avatar_preset": "emerald",
         },
     }
+    assert body["refresh_token"]
     assert auth_code.used_at is not None
     assert session.committed is True
+    refresh_records = [
+        item for item in session.added if isinstance(item, MobileRefreshToken)
+    ]
+    assert len(refresh_records) == 1
+    assert refresh_records[0].user_id == 7
+    assert refresh_records[0].token_hash == auth.hash_mobile_refresh_token(
+        body["refresh_token"]
+    )
+    assert refresh_records[0].token_hash != body["refresh_token"]
+
+
+def test_refresh_mobile_access_token_returns_new_access_token(monkeypatch):
+    refresh_record = SimpleNamespace(
+        user_id=7,
+        token_hash=auth.hash_mobile_refresh_token("refresh-token"),
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        revoked_at=None,
+        last_used_at=None,
+    )
+    db_user = SimpleNamespace(
+        id=7,
+        username="reader",
+        role="GENERAL",
+        avatar_url=None,
+        avatar_preset="blue",
+    )
+    session = FakeAuthSession(
+        execute_result=FakeExecuteResult(one=refresh_record),
+        get_result=db_user,
+    )
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(auth, "create_access_token", lambda user: f"token-for-{user.username}")
+
+    try:
+        response = client.post(
+            "/auth/mobile-refresh",
+            json={"refresh_token": "refresh-token"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "token-for-reader",
+        "user": {
+            "id": 7,
+            "username": "reader",
+            "role": "GENERAL",
+            "avatar_url": None,
+            "avatar_preset": "blue",
+        },
+    }
+    assert refresh_record.last_used_at is not None
+    assert session.committed is True
+
+
+def test_refresh_mobile_access_token_rejects_unknown_token(monkeypatch):
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=None))
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(
+        auth,
+        "create_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token created")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/mobile-refresh",
+            json={"refresh_token": "missing-token"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired mobile refresh token"
+    assert session.committed is False
+
+
+def test_refresh_mobile_access_token_rejects_revoked_token(monkeypatch):
+    refresh_record = SimpleNamespace(
+        user_id=7,
+        token_hash=auth.hash_mobile_refresh_token("refresh-token"),
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        revoked_at=datetime.now(timezone.utc),
+        last_used_at=None,
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=refresh_record))
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(
+        auth,
+        "create_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token created")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/mobile-refresh",
+            json={"refresh_token": "refresh-token"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired mobile refresh token"
+    assert refresh_record.last_used_at is None
+    assert session.committed is False
+
+
+def test_refresh_mobile_access_token_rejects_expired_token(monkeypatch):
+    refresh_record = SimpleNamespace(
+        user_id=7,
+        token_hash=auth.hash_mobile_refresh_token("refresh-token"),
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        revoked_at=None,
+        last_used_at=None,
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=refresh_record))
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(
+        auth,
+        "create_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token created")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/mobile-refresh",
+            json={"refresh_token": "refresh-token"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired mobile refresh token"
+    assert refresh_record.last_used_at is None
+    assert session.committed is False
+
+
+def test_refresh_mobile_access_token_revokes_token_for_missing_user(monkeypatch):
+    refresh_record = SimpleNamespace(
+        user_id=7,
+        token_hash=auth.hash_mobile_refresh_token("refresh-token"),
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        revoked_at=None,
+        last_used_at=None,
+    )
+    session = FakeAuthSession(
+        execute_result=FakeExecuteResult(one=refresh_record),
+        get_result=None,
+    )
+    cleanup = override_auth_db(session)
+    monkeypatch.setattr(
+        auth,
+        "create_access_token",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("token created")),
+    )
+
+    try:
+        response = client.post(
+            "/auth/mobile-refresh",
+            json={"refresh_token": "refresh-token"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired mobile refresh token"
+    assert refresh_record.revoked_at is not None
+    assert session.committed is True
+
+
+def test_mobile_logout_revokes_refresh_token():
+    refresh_record = SimpleNamespace(
+        token_hash=auth.hash_mobile_refresh_token("refresh-token"),
+        revoked_at=None,
+    )
+    session = FakeAuthSession(execute_result=FakeExecuteResult(one=refresh_record))
+    cleanup = override_auth_db(session)
+
+    try:
+        response = client.post(
+            "/auth/mobile-logout",
+            json={"refresh_token": "refresh-token"},
+        )
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Logged out"}
+    assert refresh_record.revoked_at is not None
+    assert session.committed is True
+
+
+def test_mobile_logout_without_token_is_idempotent():
+    session = FakeAuthSession()
+    cleanup = override_auth_db(session)
+
+    try:
+        response = client.post("/auth/mobile-logout", json={})
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Logged out"}
+    assert session.committed is False
 
 
 def test_exchange_mobile_auth_code_rejects_reused_code(monkeypatch):

--- a/tests/db_integration_test.py
+++ b/tests/db_integration_test.py
@@ -20,6 +20,7 @@ MODEL_MODULES = [
     "app.models.forum_model",
     "app.models.issue",
     "app.models.mobile_auth_code",
+    "app.models.mobile_refresh_token",
     "app.models.reading_list",
     "app.models.series_detail",
     "app.models.series_model",


### PR DESCRIPTION
## Summary
- Add hashed 30-day mobile refresh token storage
- Return a refresh token from the mobile auth-code exchange endpoint
- Add mobile refresh and logout endpoints
- Cover valid, expired, revoked, unknown, and missing-user refresh paths with tests

## Verification
- .\\.venv\\Scripts\\python.exe -m pytest tests\\auth_test.py
- .\\.venv\\Scripts\\python.exe -m ruff check app tests
- .\\.venv\\Scripts\\python.exe -m compileall app tests
- .\\.venv\\Scripts\\python.exe -m pytest
- git diff --check