### PR TITLE
Include direct OP replies in posts-paged roots query so they persist …

### DIFF
--- a/app/routes/forum_routes.py
+++ b/app/routes/forum_routes.py
@@ -3,7 +3,7 @@ import math
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func, delete
+from sqlalchemy import select, func, delete, or_
 from typing import Literal, Optional, List
 
 from app.database import get_async_session
@@ -489,13 +489,16 @@ async def get_thread_posts_paged(
         )
         return out
 
-    # 2) Count top-level replies (parent IS NULL) excluding OP
+    # 2) Count top-level replies (parent IS NULL or direct reply to OP) excluding OP
     total_top_level = int(
         (
             await db.execute(
                 select(func.count(ForumPost.id)).where(
                     ForumPost.thread_id == thread_id,
-                    ForumPost.parent_id.is_(None),
+                    or_(
+                        ForumPost.parent_id.is_(None),
+                        ForumPost.parent_id == first_post.id,
+                    ),
                     ForumPost.id != first_post.id,
                 )
             )
@@ -506,12 +509,17 @@ async def get_thread_posts_paged(
     page = min(page, total_pages)
 
     # 3) Page of top-level roots (stable order: oldest→newest)
+    #    Includes both null-parent posts and direct replies to the OP so the
+    #    frontend's "originalReplies" section is populated on reload.
     roots = (
         await db.execute(
             select(ForumPost)
             .where(
                 ForumPost.thread_id == thread_id,
-                ForumPost.parent_id.is_(None),
+                or_(
+                    ForumPost.parent_id.is_(None),
+                    ForumPost.parent_id == first_post.id,
+                ),
                 ForumPost.id != first_post.id,
             )
             .order_by(ForumPost.created_at.asc(), ForumPost.id.asc())


### PR DESCRIPTION
## Summary

- Forum thread replies to the original post (OP) disappeared when navigating away and returning to the thread
- The post count on the forum list remained accurate but the thread view showed no replies
- Root cause: the `/posts-paged` endpoint only queried posts where `parent_id IS NULL` as top-level roots, so posts with `parent_id = OP.id` were never included in the response on a fresh load (they only appeared while still in local state after posting)
- Fix: expand both the `total_top_level` count query and the `roots` fetch to include `parent_id = first_post.id` alongside `parent_id IS NULL`, matching what the frontend's `originalReplies` section expects

## Test plan

- [ ] Open a forum thread and reply directly to the original post
- [ ] Navigate away to the forum list
- [ ] Click back into the same thread — replies should still be visible
- [ ] Verify nested replies to those replies also render correctly
- [ ] Verify reply count on the forum list still matches what's shown in the thread