### PR TITLE
Add authenticated /forum/me/threads, /me/posts, and /me/votes endpoints with pagination and tests

### DIFF
--- a/app/routes/forum_routes.py
+++ b/app/routes/forum_routes.py
@@ -13,7 +13,7 @@ from app.models.user_model import User
 
 from app.schemas.forum_schemas import (
     ForumThreadOut, ForumPostOut, CreateThreadIn, CreatePostIn, SeriesRefOut, ThreadSettingsIn, UpdatePostIn,
-    UpdateThreadIn, PageOut, ThreadPostsPageOut
+    UpdateThreadIn, PageOut, PostsPageOut, ThreadPostsPageOut
 )
 from app.utils.forum_content import reject_disallowed_images
 
@@ -1046,4 +1046,121 @@ async def set_post_vote(
         downvote_count=downvote_count,
     )
 
+
+# ------------------------------
+# Me endpoints (auth required)
+# ------------------------------
+
+@router.get("/me/threads", response_model=PageOut)
+async def get_my_threads(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Paginated list of threads the signed-in user created."""
+    total_stmt = select(func.count(ForumThread.id)).where(
+        ForumThread.author_id == user.id
+    )
+    total = int((await db.execute(total_stmt)).scalar_one() or 0)
+
+    stmt = (
+        select(ForumThread)
+        .where(ForumThread.author_id == user.id)
+        .order_by(ForumThread.last_post_at.desc(), ForumThread.id.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    items = [await _thread_to_out(t, db) for t in rows]
+
+    total_pages = max(1, math.ceil(total / page_size))
+    return PageOut(
+        items=items,
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=total_pages,
+        has_prev=page > 1,
+        has_next=page < total_pages,
+    )
+
+
+@router.get("/me/posts", response_model=PostsPageOut)
+async def get_my_posts(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Paginated list of posts (replies) the signed-in user has written."""
+    total_stmt = select(func.count(ForumPost.id)).where(
+        ForumPost.author_id == user.id
+    )
+    total = int((await db.execute(total_stmt)).scalar_one() or 0)
+
+    stmt = (
+        select(ForumPost)
+        .where(ForumPost.author_id == user.id)
+        .order_by(ForumPost.created_at.desc(), ForumPost.id.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    items = [await _post_to_out(p, db, user) for p in rows]
+
+    total_pages = max(1, math.ceil(total / page_size))
+    return PostsPageOut(
+        items=items,
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=total_pages,
+        has_prev=page > 1,
+        has_next=page < total_pages,
+    )
+
+
+@router.get("/me/votes", response_model=PostsPageOut)
+async def get_my_votes(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Paginated list of posts the signed-in user has voted on (upvote or downvote)."""
+    total_stmt = select(func.count(ForumReaction.id)).where(
+        ForumReaction.user_id == user.id,
+        ForumReaction.kind.in_([UPVOTE, DOWNVOTE]),
+    )
+    total = int((await db.execute(total_stmt)).scalar_one() or 0)
+
+    reactions_stmt = (
+        select(ForumReaction)
+        .where(
+            ForumReaction.user_id == user.id,
+            ForumReaction.kind.in_([UPVOTE, DOWNVOTE]),
+        )
+        .order_by(ForumReaction.id.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    reactions = (await db.execute(reactions_stmt)).scalars().all()
+
+    items: list[ForumPostOut] = []
+    for reaction in reactions:
+        post = await db.get(ForumPost, reaction.post_id)
+        if post:
+            items.append(await _post_to_out(post, db, user))
+
+    total_pages = max(1, math.ceil(total / page_size))
+    return PostsPageOut(
+        items=items,
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=total_pages,
+        has_prev=page > 1,
+        has_next=page < total_pages,
+    )
 

--- a/app/schemas/forum_schemas.py
+++ b/app/schemas/forum_schemas.py
@@ -84,6 +84,16 @@ class PageOut(BaseModel):
     has_next: bool
 
 
+class PostsPageOut(BaseModel):
+    items: List[ForumPostOut]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+    has_prev: bool
+    has_next: bool
+
+
 class ThreadPostsPageOut(BaseModel):
     thread: ForumThreadOut
     posts: List[ForumPostOut]         # OP first, then this page's roots + their descendants

--- a/tests/forum_routes_test.py
+++ b/tests/forum_routes_test.py
@@ -407,3 +407,188 @@ def test_toggle_heart_compatibility_maps_to_upvote():
 
     assert response.status_code == 200
     assert response.json() == {"hearted": True, "count": 1}
+
+
+# ------------------------------
+# /me/threads tests
+# ------------------------------
+
+def test_get_my_threads_returns_users_threads():
+    thread = thread_object(author_id=10)
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=1),          # count
+            FakeExecuteResult(rows=[thread]),          # page rows
+            FakeExecuteResult(rows=[]),                # _thread_to_out: series refs
+        ],
+        get_results={(User, 10): SimpleNamespace(
+            username="reader", role="GENERAL", avatar_url=None, avatar_preset="blue"
+        )},
+    )
+    cleanup = override_forum_dependencies(session, user=user)
+
+    try:
+        response = client.get("/forum/me/threads")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["total_pages"] == 1
+    assert body["has_prev"] is False
+    assert body["has_next"] is False
+    assert len(body["items"]) == 1
+    assert body["items"][0]["title"] == "Favorite fights"
+
+
+def test_get_my_threads_returns_empty_state_when_user_has_no_threads():
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=0),   # count
+            FakeExecuteResult(rows=[]),         # page rows (empty)
+        ],
+    )
+    cleanup = override_forum_dependencies(session, user=user)
+
+    try:
+        response = client.get("/forum/me/threads")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["total_pages"] == 1
+    assert body["items"] == []
+
+
+def test_get_my_threads_requires_auth():
+    response = client.get("/forum/me/threads")
+    assert response.status_code == 401
+
+
+# ------------------------------
+# /me/posts tests
+# ------------------------------
+
+def test_get_my_posts_returns_users_posts():
+    post = post_object(author_id=10)
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=1),   # count
+            FakeExecuteResult(rows=[post]),    # page rows
+            FakeExecuteResult(rows=[]),        # _post_to_out: series refs
+            FakeExecuteResult(scalar_one=0),   # _post_vote_bits: upvote count
+            FakeExecuteResult(scalar_one=0),   # _post_vote_bits: downvote count
+            FakeExecuteResult(first=None),     # _post_vote_bits: viewer vote
+        ],
+        get_results={(User, 10): SimpleNamespace(
+            username="reader", role="GENERAL", avatar_url=None, avatar_preset="blue"
+        )},
+    )
+    cleanup = override_forum_dependencies(session, user=user)
+
+    try:
+        response = client.get("/forum/me/posts")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["content_markdown"] == "Great chapter."
+
+
+def test_get_my_posts_returns_empty_state_when_user_has_no_posts():
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=0),   # count
+            FakeExecuteResult(rows=[]),         # page rows (empty)
+        ],
+    )
+    cleanup = override_forum_dependencies(session, user=user)
+
+    try:
+        response = client.get("/forum/me/posts")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+def test_get_my_posts_requires_auth():
+    response = client.get("/forum/me/posts")
+    assert response.status_code == 401
+
+
+# ------------------------------
+# /me/votes tests
+# ------------------------------
+
+def test_get_my_votes_returns_voted_posts():
+    post = post_object(id=5, author_id=10)
+    reaction = SimpleNamespace(id=1, post_id=5, user_id=10, kind="UPVOTE")
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=1),       # count reactions
+            FakeExecuteResult(rows=[reaction]),    # page reactions
+            FakeExecuteResult(rows=[]),            # _post_to_out: series refs
+            FakeExecuteResult(scalar_one=0),       # _post_vote_bits: upvote count
+            FakeExecuteResult(scalar_one=0),       # _post_vote_bits: downvote count
+            FakeExecuteResult(first=None),         # _post_vote_bits: viewer vote
+        ],
+        get_results={
+            (ForumPost, 5): post,
+            (User, 10): SimpleNamespace(
+                username="reader", role="GENERAL", avatar_url=None, avatar_preset="blue"
+            ),
+        },
+    )
+    cleanup = override_forum_dependencies(session, user=user)
+
+    try:
+        response = client.get("/forum/me/votes")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["content_markdown"] == "Great chapter."
+
+
+def test_get_my_votes_returns_empty_state_when_user_has_no_votes():
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeForumSession(
+        results=[
+            FakeExecuteResult(scalar_one=0),   # count reactions
+            FakeExecuteResult(rows=[]),         # page reactions (empty)
+        ],
+    )
+    cleanup = override_forum_dependencies(session, user=user)
+
+    try:
+        response = client.get("/forum/me/votes")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+def test_get_my_votes_requires_auth():
+    response = client.get("/forum/me/votes")
+    assert response.status_code == 401


### PR DESCRIPTION
Adds three new authenticated endpoints to the forum router so the mobile and web clients can display a signed-in user's own activity without exposing other users' data.

GET /forum/me/threads — paginated list of threads the current user created, ordered by most recent activity. Reuses the existing PageOut schema.

GET /forum/me/posts — paginated list of posts and replies the current user has written, ordered by most recent first. Uses the new PostsPageOut schema (same shape as PageOut but with ForumPostOut items).

GET /forum/me/votes — paginated list of posts the current user has upvoted or downvoted, ordered by reaction ID descending. Also returns PostsPageOut so the client gets full post content alongside the vote record.

All three endpoints require a valid Bearer token and return 401 without one. All three support page and page_size query params with the same ge/le constraints used elsewhere in the router. PostsPageOut was added to forum_schemas.py to avoid widening the existing PageOut type.

Nine tests were added to forum_routes_test.py covering the happy path, empty state, and unauthenticated access for each endpoint. Full suite: 109 passed, 0 failures.