### PR TITLE
add thread_id to ForumPostOut so reply and vote rows can deep-link to…

### DIFF
--- a/app/routes/forum_routes.py
+++ b/app/routes/forum_routes.py
@@ -241,6 +241,7 @@ async def _post_to_out(p: ForumPost, db: AsyncSession, viewer: Optional["User"]=
 
     return ForumPostOut(
         id=p.id,
+        thread_id=p.thread_id,
         **_author_profile(author),
         content_markdown=p.content_markdown,
         created_at=str(p.created_at),

--- a/app/schemas/forum_schemas.py
+++ b/app/schemas/forum_schemas.py
@@ -14,6 +14,7 @@ class SeriesRefOut(BaseModel):
 
 class ForumPostOut(BaseModel):
     id: int
+    thread_id: int = 0
     author_username: Optional[str] = None
     author_role: Optional[str] = None
     author_avatar_url: Optional[str] = None

--- a/tests/forum_routes_test.py
+++ b/tests/forum_routes_test.py
@@ -502,6 +502,7 @@ def test_get_my_posts_returns_users_posts():
     assert body["total"] == 1
     assert len(body["items"]) == 1
     assert body["items"][0]["content_markdown"] == "Great chapter."
+    assert body["items"][0]["thread_id"] == 1
 
 
 def test_get_my_posts_returns_empty_state_when_user_has_no_posts():
@@ -566,6 +567,7 @@ def test_get_my_votes_returns_voted_posts():
     assert body["total"] == 1
     assert len(body["items"]) == 1
     assert body["items"][0]["content_markdown"] == "Great chapter."
+    assert body["items"][0]["thread_id"] == 1
 
 
 def test_get_my_votes_returns_empty_state_when_user_has_no_votes():


### PR DESCRIPTION
ForumPostOut was missing thread_id, which blocked the frontend from building deep-links from a user's reply history and vote history back to the parent thread.

Changes:
- forum_schemas.py — added thread_id: int = 0 to ForumPostOut
- forum_routes.py — passed thread_id=p.thread_id in _post_to_out()
- forum_routes_test.py — asserted thread_id == 1 on both /me/posts and /me/votes response items

All 18 unit tests pass.