### PR TITLE
add GET /series-details/me/votes endpoint so users can see the titles…

### DIFF
--- a/app/routes/series_detail.py
+++ b/app/routes/series_detail.py
@@ -1,6 +1,7 @@
-from typing import Optional
+import math
+from typing import Optional, List
 
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Depends, Request
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Depends, Request, Query
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -8,7 +9,12 @@ from app.database import get_async_session
 from app.models.series_model import Series
 from app.models.series_detail import SeriesDetail
 from app.models.user_model import User
-from app.schemas.series_detail_schemas import SeriesDetailOut
+from app.schemas.series_detail_schemas import (
+    SeriesDetailOut,
+    CategoryVoteOut,
+    MySeriesVoteOut,
+    MySeriesVotesPageOut,
+)
 from app.s3 import upload_to_s3
 from app.models.user_vote import UserVote
 from app.utils.token_utils import get_current_user
@@ -159,6 +165,72 @@ async def vote_series_detail(
     await session.refresh(detail)
     return detail
 
+
+
+@router.get("/me/votes", response_model=MySeriesVotesPageOut)
+async def get_my_series_votes(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1, le=50),
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Return the paginated list of series the current user has voted on,
+    including every category score they submitted."""
+
+    # 1. Total distinct series voted on
+    count_result = await session.execute(
+        select(func.count(func.distinct(UserVote.series_id))).where(
+            UserVote.user_id == user.id
+        )
+    )
+    total = count_result.scalar_one()
+
+    # 2. Paginated distinct series ids, most-recent first (by series id)
+    ids_result = await session.execute(
+        select(UserVote.series_id)
+        .distinct()
+        .where(UserVote.user_id == user.id)
+        .order_by(UserVote.series_id.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    series_ids: List[int] = [row[0] for row in ids_result.all()]
+
+    # 3. Build each item — one session.get + one votes query per series
+    items: List[MySeriesVoteOut] = []
+    for sid in series_ids:
+        series = await session.get(Series, sid)
+        votes_result = await session.execute(
+            select(UserVote).where(
+                UserVote.user_id == user.id,
+                UserVote.series_id == sid,
+            )
+        )
+        votes = votes_result.scalars().all()
+        items.append(
+            MySeriesVoteOut(
+                series_id=sid,
+                title=series.title if series else None,
+                cover_url=series.cover_url if series else None,
+                type=series.type.value if series and series.type else None,
+                status=series.status.value if series and series.status else None,
+                votes=[
+                    CategoryVoteOut(category=v.category, score=v.score)
+                    for v in votes
+                ],
+            )
+        )
+
+    total_pages = max(1, math.ceil(total / page_size)) if total > 0 else 1
+    return MySeriesVotesPageOut(
+        items=items,
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=total_pages,
+        has_prev=page > 1,
+        has_next=page < total_pages,
+    )
 
 
 @router.get("/{series_id}", response_model=SeriesDetailOut)

--- a/app/schemas/series_detail_schemas.py
+++ b/app/schemas/series_detail_schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 class SeriesDetailCreate(BaseModel):
     series_id: int
@@ -37,3 +37,27 @@ class SeriesDetailOut(BaseModel):
     model_config = {
         "from_attributes": True
     }
+
+
+class CategoryVoteOut(BaseModel):
+    category: str
+    score: int
+
+
+class MySeriesVoteOut(BaseModel):
+    series_id: int
+    title: Optional[str] = None
+    cover_url: Optional[str] = None
+    type: Optional[str] = None
+    status: Optional[str] = None
+    votes: List[CategoryVoteOut] = []
+
+
+class MySeriesVotesPageOut(BaseModel):
+    items: List[MySeriesVoteOut]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+    has_prev: bool
+    has_next: bool

--- a/tests/series_detail_test.py
+++ b/tests/series_detail_test.py
@@ -1,0 +1,173 @@
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routes import series_detail
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake async session tailored to /me/votes query pattern:
+#   execute() call 1 → count (scalar_one)
+#   execute() call 2 → distinct series_ids (rows of tuples)
+#   get(Series, sid)  → series object from get_results dict
+#   execute() call 3+ → UserVote rows for each series (scalars().all())
+# ---------------------------------------------------------------------------
+
+class FakeScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class FakeExecuteResult:
+    def __init__(self, *, rows=None, scalar_one=None):
+        self._rows = rows or []
+        self._scalar_one = scalar_one
+
+    def scalar_one(self):
+        return self._scalar_one
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        return FakeScalarResult(self._rows)
+
+
+class FakeSeriesDetailSession:
+    def __init__(self, *, results=None, get_results=None):
+        self._results = list(results or [])
+        self._get_results = dict(get_results or {})
+
+    async def execute(self, _stmt):
+        return self._results.pop(0)
+
+    async def get(self, model, key):
+        return self._get_results.get((model, key))
+
+
+def override_series_detail_dependencies(session, *, user=None):
+    current_user = user or SimpleNamespace(id=10, username="reader", role="GENERAL")
+
+    async def fake_get_db():
+        yield session
+
+    async def fake_current_user():
+        return current_user
+
+    app.dependency_overrides[series_detail.get_async_session] = fake_get_db
+    app.dependency_overrides[series_detail.get_current_user] = fake_current_user
+
+    def cleanup():
+        app.dependency_overrides.pop(series_detail.get_async_session, None)
+        app.dependency_overrides.pop(series_detail.get_current_user, None)
+
+    return cleanup
+
+
+def series_object(**overrides):
+    from app.models.series_model import Series
+    values = {
+        "id": 1,
+        "title": "Solo Leveling",
+        "cover_url": "https://cdn.example.com/solo.jpg",
+        "type": SimpleNamespace(value="MANHWA"),
+        "status": SimpleNamespace(value="COMPLETE"),
+        "approval_status": "APPROVED",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def vote_object(**overrides):
+    values = {
+        "id": 1,
+        "user_id": 10,
+        "series_id": 1,
+        "category": "Story",
+        "score": 9,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_get_my_series_votes_returns_voted_series():
+    from app.models.series_model import Series
+
+    series = series_object()
+    vote1 = vote_object(category="Story", score=9)
+    vote2 = vote_object(id=2, category="Art", score=8)
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+
+    session = FakeSeriesDetailSession(
+        results=[
+            FakeExecuteResult(scalar_one=1),          # count distinct series
+            FakeExecuteResult(rows=[(1,)]),            # paginated series_ids
+            FakeExecuteResult(rows=[vote1, vote2]),    # UserVote rows for series 1
+        ],
+        get_results={
+            (Series, 1): series,
+        },
+    )
+    cleanup = override_series_detail_dependencies(session, user=user)
+
+    try:
+        response = client.get("/series-details/me/votes")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["page"] == 1
+    assert body["has_prev"] is False
+    assert body["has_next"] is False
+    assert len(body["items"]) == 1
+
+    item = body["items"][0]
+    assert item["series_id"] == 1
+    assert item["title"] == "Solo Leveling"
+    assert item["cover_url"] == "https://cdn.example.com/solo.jpg"
+    assert item["type"] == "MANHWA"
+    assert item["status"] == "COMPLETE"
+    assert len(item["votes"]) == 2
+    assert {"category": "Story", "score": 9} in item["votes"]
+    assert {"category": "Art", "score": 8} in item["votes"]
+
+
+def test_get_my_series_votes_empty_state():
+    user = SimpleNamespace(id=10, username="reader", role="GENERAL")
+    session = FakeSeriesDetailSession(
+        results=[
+            FakeExecuteResult(scalar_one=0),  # count distinct series
+            FakeExecuteResult(rows=[]),        # paginated series_ids (empty)
+        ],
+    )
+    cleanup = override_series_detail_dependencies(session, user=user)
+
+    try:
+        response = client.get("/series-details/me/votes")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+    assert body["total_pages"] == 1
+    assert body["has_prev"] is False
+    assert body["has_next"] is False
+
+
+def test_get_my_series_votes_requires_auth():
+    response = client.get("/series-details/me/votes")
+    assert response.status_code == 401


### PR DESCRIPTION
New authenticated endpoint that returns a paginated list of every series the current user has voted on, grouped by series with each category score they submitted.

Changes:
- series_detail_schemas.py — added CategoryVoteOut, MySeriesVoteOut, MySeriesVotesPageOut
- series_detail.py — added GET /series-details/me/votes before the /{series_id} catch-all route; queries distinct series ids, fetches series metadata, and attaches all category votes per series
- tests/series_detail_test.py — new test file with 3 tests: happy path (1 series, 2 category votes), empty state, auth guard

All 112 unit tests pass.