### PR TITLE
Add user favourites feature (pin up to 6 series on profile)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,8 @@ import asyncio
 from sqlalchemy import text
 
 from app.routes import series_routes, auth, series_detail, reading_list_routes, issues_routes, forum_routes, \
-    forum_media_routes
+    forum_media_routes, favourite_routes
+from app.models import user_favourite  # noqa: F401 — registers model with Base
 
 from fastapi.responses import RedirectResponse, JSONResponse
 from app.routes import series_routes, auth, series_detail
@@ -74,6 +75,7 @@ app.include_router(issues_routes.router)
 app.include_router(forum_routes.router)
 app.include_router(sitemap.router)
 app.include_router(forum_media_routes.router)
+app.include_router(favourite_routes.router, prefix="/auth")
 
 # ✅ Run DB init on startup
 @app.on_event("startup")
@@ -184,6 +186,30 @@ async def on_startup():
                         UPDATE man_review.series
                         SET approval_status = 'APPROVED'
                         WHERE approval_status IS NULL
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
+                        CREATE TABLE IF NOT EXISTS man_review.user_favourites (
+                            id SERIAL PRIMARY KEY,
+                            user_id INTEGER NOT NULL
+                                REFERENCES man_review.users(id) ON DELETE CASCADE,
+                            series_id INTEGER NOT NULL
+                                REFERENCES man_review.series(id) ON DELETE CASCADE,
+                            position INTEGER NOT NULL,
+                            CONSTRAINT uq_user_favourite_series
+                                UNIQUE (user_id, series_id)
+                        )
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
+                        CREATE INDEX IF NOT EXISTS ix_user_favourites_user_id
+                            ON man_review.user_favourites (user_id)
                         """
                     )
                 )

--- a/app/models/user_favourite.py
+++ b/app/models/user_favourite.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, Integer, ForeignKey, UniqueConstraint
+from app.database import Base
+
+
+class UserFavourite(Base):
+    __tablename__ = "user_favourites"
+    __table_args__ = (
+        UniqueConstraint("user_id", "series_id", name="uq_user_favourite_series"),
+        {"schema": "man_review"},
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("man_review.users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    series_id = Column(
+        Integer,
+        ForeignKey("man_review.series.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    position = Column(Integer, nullable=False)  # 0–5

--- a/app/routes/favourite_routes.py
+++ b/app/routes/favourite_routes.py
@@ -1,0 +1,168 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.routes.auth import get_db
+from app.models.user_favourite import UserFavourite
+from app.models.series_model import Series
+from app.utils.token_utils import get_current_user
+from app.models.user_model import User
+
+router = APIRouter(prefix="/me/favourites", tags=["favourites"])
+
+MAX_FAVOURITES = 6
+
+
+# ── Schemas ──────────────────────────────────────────────────────────────────
+
+class FavouriteSeriesOut(BaseModel):
+    series_id: int
+    position: int
+    title: str
+    cover_url: Optional[str]
+    type: Optional[str]
+
+    model_config = {"from_attributes": True}
+
+
+class ReplaceFavouritesRequest(BaseModel):
+    series_ids: List[int]
+
+    @field_validator("series_ids")
+    @classmethod
+    def validate_length(cls, v: List[int]) -> List[int]:
+        if len(v) > MAX_FAVOURITES:
+            raise ValueError(f"You can pin at most {MAX_FAVOURITES} series.")
+        if len(v) != len(set(v)):
+            raise ValueError("Duplicate series IDs are not allowed.")
+        return v
+
+
+# ── Routes ───────────────────────────────────────────────────────────────────
+
+@router.get("", response_model=List[FavouriteSeriesOut])
+async def get_my_favourites(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = (
+        select(UserFavourite, Series)
+        .join(Series, Series.id == UserFavourite.series_id)
+        .where(UserFavourite.user_id == current_user.id)
+        .order_by(UserFavourite.position.asc())
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        FavouriteSeriesOut(
+            series_id=fav.series_id,
+            position=fav.position,
+            title=series.title,
+            cover_url=series.cover_url,
+            type=series.type.value if series.type else None,
+        )
+        for fav, series in rows
+    ]
+
+
+@router.put("", response_model=List[FavouriteSeriesOut])
+async def replace_my_favourites(
+    payload: ReplaceFavouritesRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    series_ids = payload.series_ids
+
+    # Verify all requested series exist
+    if series_ids:
+        stmt = select(Series).where(Series.id.in_(series_ids))
+        found = (await db.execute(stmt)).scalars().all()
+        found_ids = {s.id for s in found}
+        missing = set(series_ids) - found_ids
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Series not found: {sorted(missing)}",
+            )
+
+    # Replace all existing favourites atomically
+    await db.execute(
+        delete(UserFavourite).where(UserFavourite.user_id == current_user.id)
+    )
+    for position, series_id in enumerate(series_ids):
+        db.add(
+            UserFavourite(
+                user_id=current_user.id,
+                series_id=series_id,
+                position=position,
+            )
+        )
+    await db.commit()
+
+    # Return the updated list with series info
+    stmt = (
+        select(UserFavourite, Series)
+        .join(Series, Series.id == UserFavourite.series_id)
+        .where(UserFavourite.user_id == current_user.id)
+        .order_by(UserFavourite.position.asc())
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        FavouriteSeriesOut(
+            series_id=fav.series_id,
+            position=fav.position,
+            title=series.title,
+            cover_url=series.cover_url,
+            type=series.type.value if series.type else None,
+        )
+        for fav, series in rows
+    ]
+
+
+@router.delete("/{series_id}", response_model=List[FavouriteSeriesOut])
+async def remove_my_favourite(
+    series_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        delete(UserFavourite).where(
+            UserFavourite.user_id == current_user.id,
+            UserFavourite.series_id == series_id,
+        )
+    )
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Favourite not found.")
+
+    # Re-compact positions (0, 1, 2, …) after removal
+    stmt = (
+        select(UserFavourite)
+        .where(UserFavourite.user_id == current_user.id)
+        .order_by(UserFavourite.position.asc())
+    )
+    remaining = (await db.execute(stmt)).scalars().all()
+    for new_pos, fav in enumerate(remaining):
+        fav.position = new_pos
+
+    await db.commit()
+
+    # Return updated list with series info
+    stmt = (
+        select(UserFavourite, Series)
+        .join(Series, Series.id == UserFavourite.series_id)
+        .where(UserFavourite.user_id == current_user.id)
+        .order_by(UserFavourite.position.asc())
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        FavouriteSeriesOut(
+            series_id=fav.series_id,
+            position=fav.position,
+            title=series.title,
+            cover_url=series.cover_url,
+            type=series.type.value if series.type else None,
+        )
+        for fav, series in rows
+    ]


### PR DESCRIPTION
- New UserFavourite model with user_id, series_id, position (0-5)
- GET /auth/me/favourites — returns pinned series ordered by position
- PUT /auth/me/favourites — atomically replaces all pins (max 6)
- DELETE /auth/me/favourites/{series_id} — removes a pin and compacts positions
- Startup migration creates user_favourites table and index if not exists

# TR-###: <concise title>

## What & Why
- Jira: TR-###
- Summary:
  - …
  - …

## How to Test
- Steps / curl / screenshots if applicable

## Checklist
- [ ] PR title starts with **TR-###** (e.g., `TR-8: Add PR template`)
- [ ] Branch named **TR-###-<dev>-<short-desc>** (e.g., `TR-8-kenneth-pr-template`)
- [ ] Commits include the Jira key (`TR-###`) in the message
- [ ] Lint/format pass (`black .`, `flake8`)
- [ ] Tests added/updated (pytest) if applicable
