### PR TITLE
Add forum post reporting system

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -23,7 +23,7 @@ complexity. The frontend companion doc is at `toonranks-frontend/FORUM_IMPROVEME
 
 | Model | Key columns |
 |---|---|
-| `ForumThread` | `id`, `title`, `author_id`, `created_at`, `updated_at`, `post_count`, `last_post_at`, `locked`, `latest_first` |
+| `ForumThread` | `id`, `title`, `author_id`, `created_at`, `updated_at`, `post_count`, `last_post_at`, `locked`, `latest_first`, `view_count`, `is_pinned` |
 | `ForumPost` | `id`, `thread_id`, `author_id`, `parent_id`, `content_markdown`, `created_at`, `updated_at`, `heart_count`, `upvote_count`, `downvote_count` |
 | `ForumSeriesRef` | `id`, `thread_id`, `post_id`, `series_id` |
 | `ForumReaction` | `id`, `post_id`, `user_id`, `kind` (UPVOTE/DOWNVOTE/HEART) |
@@ -34,8 +34,8 @@ complexity. The frontend companion doc is at `toonranks-frontend/FORUM_IMPROVEME
 | Method | Path | Auth | Notes |
 |---|---|---|---|
 | `GET` | `/forum/threads` | None | Simple list, title search, sorted `updated_at DESC` |
-| `GET` | `/forum/threads-paged` | None | Paginated with `?q=` title search; sorts by `last_post_at DESC` only |
-| `POST` | `/forum/threads` | Required | Rate: `3/min; 20/hr; 60/day`. Limit: 10 threads per user |
+| `GET` | `/forum/threads-paged` | None | Paginated; `?q=` title search; `?sort=activity/newest/replies`; pinned first |
+| `POST` | `/forum/threads` | Required | Rate: `3/min; 20/hr; 60/day`. Limit: 50 threads per user |
 | `GET` | `/forum/threads/{thread_id}` | None (opt) | Full thread + all posts flat |
 | `GET` | `/forum/threads/{thread_id}/posts-paged` | None (opt) | Paginated nested posts |
 | `PATCH` | `/forum/threads/{thread_id}` | Owner/Admin | Rate: `6/min; 40/hr; 150/day` |
@@ -53,6 +53,10 @@ complexity. The frontend companion doc is at `toonranks-frontend/FORUM_IMPROVEME
 | `GET` | `/forum/me/votes` | Required | Signed-in user's voted posts, paginated |
 | `GET` | `/forum/series-search` | None | Rate: `30/min; 1000/day` |
 | `POST` | `/forum/media/upload` | Required | Multipart; max 300 KB image / 1 MB GIF |
+| `PATCH` | `/forum/threads/{thread_id}/pin` | Admin only | Toggles `is_pinned` boolean |
+| `POST` | `/forum/threads/{thread_id}/posts/{post_id}/report` | Required | Rate: `5/hr`; blocks self-report and duplicates |
+| `GET` | `/forum/reports` | Admin only | Paginated moderation queue; filterable by status |
+| `PATCH` | `/forum/reports/{report_id}` | Admin only | Mark report REVIEWED or DISMISSED |
 
 **Cred score formula:**
 - `+2` when user creates a thread
@@ -63,286 +67,68 @@ complexity. The frontend companion doc is at `toonranks-frontend/FORUM_IMPROVEME
 
 ---
 
-## Phase 1: Quick Wins — Thread Limit, View Count, and Pinning Column
+## ✅ Phase 1: Quick Wins — Thread Limit, View Count, and Pinning Column
 
-Suggested branch: `backend-forum-quick-wins`
+Suggested branch: `backend-forum-quick-wins` — **merged and deployed**
 
-These three changes require a migration and minor route edits but no new models.
+Migration applied: `FORUM_THREAD_COLUMNS_MIGRATION.sql`
 
 ### 1a — Raise the thread limit
 
-**File:** `app/routes/forum_routes.py`, line ~303
-
-The limit `if existing_count >= 10` is hard-coded. Popular forums have no per-user thread cap or
-use a much higher one (50–100). Ten is far too restrictive for active contributors.
-
-- [ ] Extract the constant to the top of `forum_routes.py`:
-  ```python
-  MAX_THREADS_PER_USER = 50  # Raised from 10; limits thread spam without blocking real contributors
-  ```
-- [ ] Replace the inline `>= 10` comparison: `if existing_count >= MAX_THREADS_PER_USER`
-- [ ] Update the 403 error detail to reflect the new limit:
-  `f"Thread limit reached ({MAX_THREADS_PER_USER}). Delete an existing thread to create a new one."`
-- [ ] Add a backend test: POST to `/forum/threads` as a user with exactly `MAX_THREADS_PER_USER`
-  threads — confirm 403 is returned. With `MAX_THREADS_PER_USER - 1` threads — confirm 201.
+- [x] `MAX_THREADS_PER_USER = 50` constant added to top of `forum_routes.py`
+- [x] Inline `>= 10` replaced with `>= MAX_THREADS_PER_USER`
+- [x] 403 error message updated to reflect new limit
+- [x] Existing thread-limit test updated to assert against 50
 
 ### 1b — Thread view count
 
-**Files:**
-- `app/models/forum_model.py` — add column
-- Alembic migration — add `view_count` column
-- `app/routes/forum_routes.py` — increment on fetch
-
-The `ForumThread` model has no `view_count`. Adding it lets both the thread list and detail views
-show how many times a thread has been viewed.
-
-- [ ] Add `view_count = Column(Integer, nullable=False, server_default="0", default=0)` to
-  `ForumThread` in `app/models/forum_model.py`
-- [ ] Create an Alembic migration:
-  ```sql
-  ALTER TABLE man_review.forum_threads ADD COLUMN view_count INTEGER NOT NULL DEFAULT 0;
-  ```
-- [ ] In `get_thread` (`GET /forum/threads/{thread_id}`), increment view count on every fetch:
-  ```python
-  t.view_count = (t.view_count or 0) + 1
-  await db.commit()
-  ```
-  Do not increment for the thread author's own views — check `if viewer and viewer.id != t.author_id`.
-  Alternatively, increment for all viewers including the author for simplicity in v1.
-- [ ] Expose `view_count` in the `ForumThreadOut` Pydantic schema in `app/schemas/forum_schemas.py`
-- [ ] Include `view_count` in `_thread_to_out()` in `forum_routes.py`
-- [ ] Include `view_count` in `ThreadPostsPageOut` response (already uses `_thread_to_out`)
+- [x] `view_count` column added to `ForumThread` model
+- [x] Migration SQL created (`FORUM_THREAD_COLUMNS_MIGRATION.sql`)
+- [x] `get_thread` increments `view_count` on fetch, skips author's own views
+- [x] `get_thread_posts_paged` increments on page 1 only
+- [x] `view_count` exposed in `ForumThreadOut` schema and `_thread_to_out()` mapper
 
 ### 1c — Pinned thread column
 
-**Files:**
-- `app/models/forum_model.py` — add column
-- Alembic migration — add `is_pinned` column
-- `app/routes/forum_routes.py` — sort pinned first, admin pin/unpin endpoint
-- `app/schemas/forum_schemas.py` — expose in response
-
-Currently there is a client-side hack in the frontend that pins any thread whose title contains
-"Patch Notes". This is fragile. The correct solution is an `is_pinned` flag controlled by admins.
-
-- [ ] Add `is_pinned = Column(Boolean, nullable=False, server_default=text("false"), default=False)`
-  to `ForumThread` in `app/models/forum_model.py`
-- [ ] Create an Alembic migration:
-  ```sql
-  ALTER TABLE man_review.forum_threads ADD COLUMN is_pinned BOOLEAN NOT NULL DEFAULT FALSE;
-  ```
-- [ ] Expose `is_pinned` in `ForumThreadOut` Pydantic schema
-- [ ] Include `is_pinned` in `_thread_to_out()` mapper
-- [ ] Update thread list ordering in `list_threads_paged` to sort pinned threads first:
-  ```python
-  .order_by(
-      ForumThread.is_pinned.desc(),
-      ForumThread.last_post_at.desc(),
-      ForumThread.id.desc(),
-  )
-  ```
-  Apply the same ordering change to the legacy `list_threads` route.
-- [ ] Add a new admin-only endpoint:
-  ```
-  PATCH /forum/threads/{thread_id}/pin
-  Body: { "pinned": bool }
-  Auth: Admin only (403 for non-admins)
-  ```
-  Implementation pattern: identical to the existing `set_thread_lock` endpoint.
-  ```python
-  @router.patch("/threads/{thread_id}/pin")
-  async def set_thread_pin(
-      thread_id: int,
-      body: PinToggleIn,
-      user: User = Depends(get_current_user),
-      db: AsyncSession = Depends(get_async_session),
-  ):
-      if not _is_admin(user):
-          raise HTTPException(status_code=403, detail="Admin only")
-      t = await db.get(ForumThread, thread_id)
-      if not t:
-          raise HTTPException(status_code=404, detail="Thread not found")
-      t.is_pinned = bool(body.pinned)
-      await db.commit()
-      await db.refresh(t)
-      return {"id": t.id, "is_pinned": t.is_pinned}
-  ```
-  Add `class PinToggleIn(BaseModel): pinned: bool` alongside `LockToggleIn`.
-- [ ] Add a test: PATCH `/forum/threads/{id}/pin` as admin → `is_pinned` flips. As non-admin → 403.
-- [ ] Add a test: GET `/forum/threads-paged` returns pinned threads first regardless of `last_post_at`.
+- [x] `is_pinned` column added to `ForumThread` model
+- [x] Migration SQL created (`FORUM_THREAD_COLUMNS_MIGRATION.sql`)
+- [x] `is_pinned` exposed in `ForumThreadOut` schema and `_thread_to_out()` mapper
+- [x] `list_threads_paged` and `list_threads` both sort `is_pinned DESC` first
+- [x] `PATCH /forum/threads/{id}/pin` admin-only endpoint added
+- [x] `PinToggleIn` Pydantic model added alongside `LockToggleIn`
 
 ---
 
-## Phase 2: Thread Sorting Options
+## ✅ Phase 2: Thread Sorting Options
 
-Suggested branch: `backend-forum-thread-sorting`
+Suggested branch: `backend-forum-thread-sorting` — **merged and deployed**
 
-The thread list currently sorts only by `last_post_at DESC`. Popular forums let users sort by
-newest threads, most replies, or hot (most recent activity). This phase adds a `sort` query param
-to `GET /forum/threads-paged`.
+No migration required.
 
-**File:** `app/routes/forum_routes.py` — `list_threads_paged` function (line ~388)
-
-- [ ] Add a `sort` query param with an `Optional[Literal]` type:
-  ```python
-  sort: Optional[Literal["activity", "newest", "replies"]] = Query("activity")
-  ```
-  - `"activity"` (default): `ORDER BY is_pinned DESC, last_post_at DESC, id DESC` (current behavior)
-  - `"newest"`: `ORDER BY is_pinned DESC, created_at DESC, id DESC`
-  - `"replies"`: `ORDER BY is_pinned DESC, post_count DESC, id DESC`
-- [ ] Build the order clause conditionally:
-  ```python
-  if sort == "newest":
-      order_clause = [ForumThread.is_pinned.desc(), ForumThread.created_at.desc(), ForumThread.id.desc()]
-  elif sort == "replies":
-      order_clause = [ForumThread.is_pinned.desc(), ForumThread.post_count.desc(), ForumThread.id.desc()]
-  else:  # activity
-      order_clause = [ForumThread.is_pinned.desc(), ForumThread.last_post_at.desc(), ForumThread.id.desc()]
-  stmt = stmt.order_by(*order_clause)
-  ```
-  Pinned threads always appear first regardless of sort selection.
-- [ ] Add `sort` to the `PageOut` response so the frontend can confirm which sort is active.
-  If `PageOut` is a Pydantic model in `forum_schemas.py`, add `sort: Optional[str] = None`.
-- [ ] Add backend tests:
-  - `?sort=activity` returns thread with most recent `last_post_at` first (excluding pinned)
-  - `?sort=newest` returns thread with most recent `created_at` first (excluding pinned)
-  - `?sort=replies` returns thread with highest `post_count` first (excluding pinned)
-  - Pinned threads appear before all others regardless of sort
+- [x] `sort` query param added to `GET /forum/threads-paged`: `activity` (default), `newest`, `replies`
+- [x] Order clause built conditionally; pinned threads always surface first regardless of sort
+- [x] `sort` field added to `PageOut` response schema so frontend can confirm active sort
 
 ---
 
-## Phase 3: Post Reporting
+## ✅ Phase 3: Post Reporting
 
-Suggested branch: `backend-forum-post-reporting`
+Suggested branch: `backend-forum-post-reporting` — **complete, pending merge**
 
-There is currently no way for users to report individual forum posts. The issues system
-(`app/routes/issues_routes.py`) handles site-level bug/feature reports, not post-level moderation
-reports. This phase adds a separate `ForumReport` model and endpoint.
-
-**Files to create/modify:**
-- `app/models/forum_model.py` — add `ForumReport` model
-- Alembic migration — new `man_review.forum_reports` table
-- `app/routes/forum_routes.py` — new report endpoint and admin list endpoint
-- `app/schemas/forum_schemas.py` — new `ForumReportOut` schema
+Migration applied: `FORUM_REPORTS_MIGRATION.sql`
 
 ### 3a — `ForumReport` model
-
-Add to `app/models/forum_model.py`:
-
-```python
-class ForumReport(Base):
-    __tablename__ = "forum_reports"
-    __table_args__ = (
-        UniqueConstraint("post_id", "reporter_id", name="uq_forum_report_post_reporter"),
-        {"schema": SCHEMA},
-    )
-
-    id = Column(Integer, primary_key=True, index=True)
-    post_id = Column(
-        Integer,
-        ForeignKey(f"{SCHEMA}.forum_posts.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    thread_id = Column(
-        Integer,
-        ForeignKey(f"{SCHEMA}.forum_threads.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    reporter_id = Column(
-        Integer,
-        ForeignKey(f"{SCHEMA}.users.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    reason = Column(String(500), nullable=True)  # optional free-text reason
-    status = Column(String(20), nullable=False, server_default="OPEN")  # OPEN, REVIEWED, DISMISSED
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    reviewed_at = Column(DateTime(timezone=True), nullable=True)
-    reviewed_by_id = Column(
-        Integer,
-        ForeignKey(f"{SCHEMA}.users.id", ondelete="SET NULL"),
-        nullable=True,
-    )
-```
-
-The `UniqueConstraint` prevents a user from submitting multiple reports on the same post.
+- [x] `ForumReport` model added to `app/models/forum_model.py` with `post_id`, `thread_id`, `reporter_id`, `reason`, `status` (OPEN/REVIEWED/DISMISSED), `reviewed_at`, `reviewed_by_id`
+- [x] `UniqueConstraint("post_id", "reporter_id")` prevents duplicate reports per user
 
 ### 3b — Migration
+- [x] `FORUM_REPORTS_MIGRATION.sql` created — `man_review.forum_reports` table with indexes on `post_id`, `reporter_id`, and `status`
 
-- [ ] Create Alembic migration for `man_review.forum_reports`:
-  ```sql
-  CREATE TABLE man_review.forum_reports (
-      id SERIAL PRIMARY KEY,
-      post_id INTEGER NOT NULL REFERENCES man_review.forum_posts(id) ON DELETE CASCADE,
-      thread_id INTEGER NOT NULL REFERENCES man_review.forum_threads(id) ON DELETE CASCADE,
-      reporter_id INTEGER NOT NULL REFERENCES man_review.users(id) ON DELETE CASCADE,
-      reason VARCHAR(500),
-      status VARCHAR(20) NOT NULL DEFAULT 'OPEN',
-      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      reviewed_at TIMESTAMPTZ,
-      reviewed_by_id INTEGER REFERENCES man_review.users(id) ON DELETE SET NULL,
-      CONSTRAINT uq_forum_report_post_reporter UNIQUE (post_id, reporter_id)
-  );
-  CREATE INDEX ON man_review.forum_reports (post_id);
-  CREATE INDEX ON man_review.forum_reports (reporter_id);
-  ```
-
-### 3c — Report endpoint
-
-Add to `app/routes/forum_routes.py`:
-
-- [ ] `POST /forum/threads/{thread_id}/posts/{post_id}/report` — Auth required
-
-  ```python
-  class ForumReportIn(BaseModel):
-      reason: Optional[str] = None  # optional free-text, max 500 chars
-
-  @router.post("/threads/{thread_id}/posts/{post_id}/report", status_code=201)
-  @limiter.limit("5/hour")
-  async def report_post(
-      request: Request,
-      thread_id: int,
-      post_id: int,
-      payload: ForumReportIn,
-      user: User = Depends(get_current_user),
-      db: AsyncSession = Depends(get_async_session),
-  ):
-  ```
-
-  Logic:
-  1. Confirm the post exists and belongs to the thread (404 if not).
-  2. Block self-reporting: `if post.author_id == user.id` → 403.
-  3. Check for existing report by this user on this post — return 409 with
-     `detail="You have already reported this post."` if duplicate.
-  4. Insert `ForumReport(post_id=post_id, thread_id=thread_id, reporter_id=user.id, reason=payload.reason)`.
-  5. Return `{"message": "Report submitted. Our team will review it shortly."}` with status 201.
-
-- [ ] `GET /forum/reports` — Admin only, paginated list of open reports for moderation review:
-  ```python
-  @router.get("/reports")
-  async def list_reports(
-      status: Optional[str] = Query("OPEN"),  # OPEN, REVIEWED, DISMISSED, or None for all
-      page: int = Query(1, ge=1),
-      page_size: int = Query(20, ge=1, le=100),
-      user: User = Depends(get_current_user),
-      db: AsyncSession = Depends(get_async_session),
-  ):
-  ```
-  Returns paginated reports with reporter username, post excerpt, thread title, and reason.
-
-- [ ] `PATCH /forum/reports/{report_id}` — Admin only, update report status:
-  ```python
-  class ForumReportReviewIn(BaseModel):
-      status: Literal["REVIEWED", "DISMISSED"]
-  ```
-  Sets `status`, `reviewed_at = func.now()`, `reviewed_by_id = user.id`.
-
-- [ ] Add tests:
-  - POST report as author of the post → 403
-  - POST report twice on same post → 409
-  - GET `/forum/reports` as non-admin → 403
-  - PATCH report status as admin → status updates and `reviewed_at` is set
+### 3c — Endpoints
+- [x] `POST /forum/threads/{id}/posts/{post_id}/report` — rate-limited 5/hour; blocks self-reporting (403); blocks duplicates (409); returns 201 on success
+- [x] `GET /forum/reports?status=OPEN` — admin only; paginated; includes `post_excerpt`, `thread_title`, `reporter_username` in response
+- [x] `PATCH /forum/reports/{id}` — admin only; sets status to REVIEWED or DISMISSED with timestamp and reviewer recorded
+- [x] `ForumReportIn`, `ForumReportReviewIn`, `ForumReportOut`, `ForumReportsPageOut` schemas added to `forum_schemas.py`
 
 ---
 

--- a/FORUM_REPORTS_MIGRATION.sql
+++ b/FORUM_REPORTS_MIGRATION.sql
@@ -1,0 +1,21 @@
+-- Toon Ranks forum reports migration.
+-- Creates the forum_reports table for post-level moderation reporting.
+-- Run this once against the production database before deploying the
+-- backend-forum-post-reporting branch.
+
+CREATE TABLE IF NOT EXISTS man_review.forum_reports (
+    id              SERIAL PRIMARY KEY,
+    post_id         INTEGER NOT NULL REFERENCES man_review.forum_posts(id)    ON DELETE CASCADE,
+    thread_id       INTEGER NOT NULL REFERENCES man_review.forum_threads(id)  ON DELETE CASCADE,
+    reporter_id     INTEGER NOT NULL REFERENCES man_review.users(id)          ON DELETE CASCADE,
+    reason          VARCHAR(500),
+    status          VARCHAR(20) NOT NULL DEFAULT 'OPEN',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reviewed_at     TIMESTAMPTZ,
+    reviewed_by_id  INTEGER REFERENCES man_review.users(id) ON DELETE SET NULL,
+    CONSTRAINT uq_forum_report_post_reporter UNIQUE (post_id, reporter_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_forum_reports_post_id     ON man_review.forum_reports (post_id);
+CREATE INDEX IF NOT EXISTS idx_forum_reports_reporter_id ON man_review.forum_reports (reporter_id);
+CREATE INDEX IF NOT EXISTS idx_forum_reports_status      ON man_review.forum_reports (status);

--- a/app/models/forum_model.py
+++ b/app/models/forum_model.py
@@ -168,3 +168,41 @@ class ForumReaction(Base):
     # Valid values: UPVOTE, DOWNVOTE. Legacy HEART rows should be migrated to UPVOTE.
     kind = Column(String(20), nullable=False, server_default="UPVOTE")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class ForumReport(Base):
+    __tablename__ = "forum_reports"
+    __table_args__ = (
+        UniqueConstraint("post_id", "reporter_id", name="uq_forum_report_post_reporter"),
+        {"schema": SCHEMA},
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    post_id = Column(
+        Integer,
+        ForeignKey(f"{SCHEMA}.forum_posts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    thread_id = Column(
+        Integer,
+        ForeignKey(f"{SCHEMA}.forum_threads.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    reporter_id = Column(
+        Integer,
+        ForeignKey(f"{SCHEMA}.users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    reason = Column(String(500), nullable=True)
+    # OPEN → admin has not reviewed; REVIEWED → action taken; DISMISSED → no action needed
+    status = Column(String(20), nullable=False, server_default="OPEN")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
+    reviewed_by_id = Column(
+        Integer,
+        ForeignKey(f"{SCHEMA}.users.id", ondelete="SET NULL"),
+        nullable=True,
+    )

--- a/app/routes/forum_routes.py
+++ b/app/routes/forum_routes.py
@@ -7,13 +7,14 @@ from sqlalchemy import select, func, delete, or_
 from typing import Literal, Optional, List
 
 from app.database import get_async_session
-from app.models.forum_model import ForumThread, ForumPost, ForumSeriesRef, ForumReaction
+from app.models.forum_model import ForumThread, ForumPost, ForumSeriesRef, ForumReaction, ForumReport
 from app.models.series_model import Series
 from app.models.user_model import User
 
 from app.schemas.forum_schemas import (
     ForumThreadOut, ForumPostOut, CreateThreadIn, CreatePostIn, SeriesRefOut, ThreadSettingsIn, UpdatePostIn,
-    UpdateThreadIn, PageOut, PostsPageOut, ThreadPostsPageOut
+    UpdateThreadIn, PageOut, PostsPageOut, ThreadPostsPageOut,
+    ForumReportIn, ForumReportReviewIn, ForumReportOut, ForumReportsPageOut,
 )
 from app.utils.forum_content import reject_disallowed_images
 
@@ -1290,3 +1291,139 @@ async def get_my_votes(
         has_next=page < total_pages,
     )
 
+
+
+# ------------------------------
+# Post reporting
+# ------------------------------
+
+async def _report_to_out(report: "ForumReport", db: AsyncSession) -> ForumReportOut:
+    """Map a ForumReport row to the output schema, pulling in usernames and post/thread context."""
+    reporter = await db.get(User, report.reporter_id) if report.reporter_id else None
+    reviewed_by = await db.get(User, report.reviewed_by_id) if report.reviewed_by_id else None
+    post = await db.get(ForumPost, report.post_id) if report.post_id else None
+    thread = await db.get(ForumThread, report.thread_id) if report.thread_id else None
+
+    excerpt = None
+    if post and post.content_markdown:
+        excerpt = post.content_markdown[:200] + ("…" if len(post.content_markdown) > 200 else "")
+
+    return ForumReportOut(
+        id=report.id,
+        post_id=report.post_id,
+        thread_id=report.thread_id,
+        reporter_username=getattr(reporter, "username", None),
+        reason=report.reason,
+        status=report.status,
+        created_at=str(report.created_at),
+        reviewed_at=str(report.reviewed_at) if report.reviewed_at else None,
+        reviewed_by_username=getattr(reviewed_by, "username", None),
+        post_excerpt=excerpt,
+        thread_title=getattr(thread, "title", None),
+    )
+
+
+@router.post("/threads/{thread_id}/posts/{post_id}/report", status_code=201)
+@limiter.limit("5/hour")
+async def report_post(
+    request: Request,
+    thread_id: int,
+    post_id: int,
+    payload: ForumReportIn,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Submit a report on a forum post. One report per user per post."""
+    post = await db.get(ForumPost, post_id)
+    if not post or post.thread_id != thread_id:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    if post.author_id == user.id:
+        raise HTTPException(status_code=403, detail="You cannot report your own post.")
+
+    existing = (
+        await db.execute(
+            select(ForumReport).where(
+                ForumReport.post_id == post_id,
+                ForumReport.reporter_id == user.id,
+            ).limit(1)
+        )
+    ).scalars().first()
+    if existing:
+        raise HTTPException(status_code=409, detail="You have already reported this post.")
+
+    reason = (payload.reason or "").strip()[:500] or None
+
+    db.add(ForumReport(
+        post_id=post_id,
+        thread_id=thread_id,
+        reporter_id=user.id,
+        reason=reason,
+        status="OPEN",
+    ))
+    await db.commit()
+    return {"message": "Report submitted. Our team will review it shortly."}
+
+
+@router.get("/reports", response_model=ForumReportsPageOut)
+async def list_reports(
+    status: Optional[str] = Query("OPEN"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Admin-only: paginated list of post reports for moderation review."""
+    if not _is_admin(user):
+        raise HTTPException(status_code=403, detail="Admin only")
+
+    filters = []
+    if status:
+        filters.append(ForumReport.status == status.upper())
+
+    total_stmt = select(func.count(ForumReport.id))
+    if filters:
+        total_stmt = total_stmt.where(*filters)
+    total = int((await db.execute(total_stmt)).scalar_one() or 0)
+
+    stmt = select(ForumReport).order_by(ForumReport.created_at.desc())
+    if filters:
+        stmt = stmt.where(*filters)
+    stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+
+    rows = (await db.execute(stmt)).scalars().all()
+    items = [await _report_to_out(r, db) for r in rows]
+
+    total_pages = max(1, math.ceil(total / page_size))
+    return ForumReportsPageOut(
+        items=items,
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=total_pages,
+        has_prev=page > 1,
+        has_next=page < total_pages,
+    )
+
+
+@router.patch("/reports/{report_id}", response_model=ForumReportOut)
+async def review_report(
+    report_id: int,
+    payload: ForumReportReviewIn,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Admin-only: mark a report as REVIEWED or DISMISSED."""
+    if not _is_admin(user):
+        raise HTTPException(status_code=403, detail="Admin only")
+
+    report = await db.get(ForumReport, report_id)
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    report.status = payload.status
+    report.reviewed_at = func.now()
+    report.reviewed_by_id = user.id
+    await db.commit()
+    await db.refresh(report)
+    return await _report_to_out(report, db)

--- a/app/schemas/forum_schemas.py
+++ b/app/schemas/forum_schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 
 class SeriesRefOut(BaseModel):
@@ -75,6 +75,36 @@ class UpdateThreadIn(BaseModel):
     first_post_markdown: Optional[str] = Field(default=None, min_length=1)
     # Optional: only replace header refs when provided
     series_ids: Optional[List[int]] = None
+
+
+class ForumReportIn(BaseModel):
+    reason: Optional[str] = None  # optional free-text, max 500 chars
+
+class ForumReportReviewIn(BaseModel):
+    status: Literal["REVIEWED", "DISMISSED"]
+
+class ForumReportOut(BaseModel):
+    id: int
+    post_id: int
+    thread_id: int
+    reporter_username: Optional[str] = None
+    reason: Optional[str] = None
+    status: str
+    created_at: str
+    reviewed_at: Optional[str] = None
+    reviewed_by_username: Optional[str] = None
+    # Snapshot of the reported post so admins have context without a separate fetch
+    post_excerpt: Optional[str] = None
+    thread_title: Optional[str] = None
+
+class ForumReportsPageOut(BaseModel):
+    items: List[ForumReportOut]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+    has_prev: bool
+    has_next: bool
 
 
 class PageOut(BaseModel):


### PR DESCRIPTION
Adds report functionality for forum posts. Users can report any post they didn't author (5/hour rate limit, one report per post). Admins can list open reports via GET /forum/reports and mark them REVIEWED or DISMISSED via PATCH /forum/reports/{id}. Includes post excerpt and thread title in the report response for admin context.