### PR TITLE
docs: add AI-native documentation and workflow constraints

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -5,6 +5,9 @@ FastAPI + SQLAlchemy async backend for a manga/manhwa/manhua ranking platform.
 Python 3.11+, PostgreSQL (schema: man_review), Railway deployment.
 
 ## Hard rules
+- **Read CONSTRAINTS.md** — it defines the full workflow and handoff requirements
+- Never commit or push without explicit instruction from the owner
+- Always end every task with: numbered test steps + one-line commit message + short PR description
 - Never work on `main` — always create a branch
 - All database access is async — use `await` on every execute/commit/refresh
 - Every ORM model must have `__table_args__ = {"schema": "man_review"}` — omitting this breaks prod

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ docs/                reference docs (architecture, data model, API, conventions)
 
 ## Non-negotiable rules
 
+> See `CONSTRAINTS.md` for the full workflow. Key points repeated here:
+
+- **Never commit or push without explicit instruction** — wait to be told; finishing a task does not mean commit
+- **Always end every task with** numbered test steps + one-line commit message + short PR description
 - **Never work on `main` directly** — always a branch
 - **All DB calls must be async** — `await session.execute(...)`, `await session.commit()`
 - **All models must include** `__table_args__ = {"schema": "man_review"}`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 AI coding assistant entry point. Read this before touching any code.
 
+> ⚠️ **Read `CONSTRAINTS.md` first.** It defines the non-negotiable workflow rules:
+> never commit/push without explicit instruction, always end every task with test
+> steps + a commit message + a PR description, one branch per task.
+
 ---
 
 ## What this project is
@@ -114,9 +118,12 @@ ruff check . --fix
 
 ## Critical rules — read before writing any code
 
-1. **Never work directly on `main`.** Create a branch. Branch naming: `backend-<short-desc>` (e.g. `backend-fix-vote-count`).
-2. **Never commit or push** unless the user explicitly asks.
-3. **All database access is async.** Use `await db.execute(...)`, `await db.commit()`, etc. Never call sync SQLAlchemy methods.
+> Full workflow constraints are in `CONSTRAINTS.md`. The short version:
+
+1. **Never commit or push without explicit instruction from the owner.** Finishing a task does not mean you commit. Wait to be told.
+2. **Always end every task with:** numbered test steps (pytest / API calls), a one-line commit message, and a short GitHub PR description. No exceptions.
+3. **Never work directly on `main`.** Create a branch. Branch naming: `backend-<short-desc>` (e.g. `backend-fix-vote-count`).
+4. **All database access is async.** Use `await db.execute(...)`, `await db.commit()`, etc. Never call sync SQLAlchemy methods.
 4. **Session dependency:** use `get_async_session` from `app.database` for most routes. Only `series_routes` and `auth` use the local `get_db()` helper — don't mix them in new code; prefer `get_async_session`.
 5. **Schema is `man_review`.** Every model has `__table_args__ = {"schema": "man_review"}`. Never omit this.
 6. **Role system:** `GENERAL` < `CONTRIBUTOR` < `ADMIN`. Use deps from `app.deps.admin` (`require_admin`, `require_series_submitter`, `is_admin`, `can_submit_series`). Never hard-code role strings in route logic.

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -1,0 +1,94 @@
+# AI Assistant Constraints — Toon Ranks Backend
+
+These rules apply to every AI assistant working in this repository without exception.
+They are repeated in `CLAUDE.md`, `AGENTS.md`, and `.cursorrules` — if you are reading
+any of those files, these constraints still apply.
+
+---
+
+## Workflow — how work gets shipped
+
+```
+AI creates feature branch
+        │
+        ▼
+AI does the work on that branch
+        │
+        ▼
+AI hands off:
+  1. Test steps (API calls, UI steps, or pytest commands to verify the change)
+  2. Short commit message
+  3. Short GitHub PR description
+        │
+        ▼
+Owner reviews — ONLY commits and pushes when explicitly told to
+        │
+        ▼
+Owner creates PR → main
+        │
+        ▼
+Railway auto-deploys on merge to main
+```
+
+---
+
+## Hard constraints
+
+### 1. Never commit or push without explicit instruction
+Do not run `git commit`, `git push`, `git merge`, or open a PR unless the owner
+explicitly says "commit", "push", or "commit and push". Completing a task does
+**not** imply permission to commit. Always wait to be asked.
+
+### 2. Always provide a handoff at the end of every task
+When you finish work on a branch, always end your response with:
+
+**Test steps** — how to verify the change works. For backend changes this is
+typically a combination of:
+- `pytest tests/my_feature_test.py` command
+- API calls to make (method, URL, payload, expected response)
+- Any UI steps on the frontend that exercise the endpoint
+
+Example:
+```
+1. Run: pytest tests/auth_test.py -v
+2. POST /auth/login with valid credentials — expected: 200 + access_token
+3. POST /auth/login with wrong password — expected: 401 Invalid credentials
+```
+
+**Commit message** — one line, imperative, under 72 characters:
+```
+feat: add EXTRA_CORS_ORIGINS env-driven config for UAT support
+```
+
+**GitHub PR description** — short summary + test plan checklist:
+```
+## Summary
+- Adds EXTRA_CORS_ORIGINS to config.py (comma-separated env var)
+- Spreads into CORS allow_origins in main.py
+- No code change needed to add new origins — set the env var in Railway
+
+## Test plan
+- [ ] pytest passes
+- [ ] UAT origin accepted (check CORS headers in browser network tab)
+- [ ] Production origins still work
+```
+
+### 3. One branch per task
+Never mix unrelated changes on the same branch. If you notice something else
+that needs fixing while working, flag it as a follow-up, do not fix it inline.
+
+### 4. Never work directly on `main`
+All work goes on a feature branch named `backend-<short-desc>`. The owner
+merges to `main` via a PR after reviewing.
+
+### 5. Ask before assuming on anything ambiguous
+If a requirement is unclear, ask one focused question before writing code.
+Do not make assumptions and build the wrong thing.
+
+---
+
+## Branch naming
+
+`backend-<short-desc>`
+
+Examples: `backend-cors-env-origins`, `backend-fix-vote-count`, `backend-forum-read-state`


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md, AGENTS.md, .cursorrules — AI assistant entry points
- Adds CONSTRAINTS.md — workflow rules (no commit without instruction, always hand off test steps + commit message + PR description)
- Adds docs/ARCHITECTURE.md, docs/DATA_MODEL.md, docs/API.md, docs/CONVENTIONS.md
- Updates CONTRIBUTING.md with full local setup, test commands, pre-PR checklist

## Test plan
- [ ] Docs only — no code changes, no tests needed
- [ ] Verify all files appear on GitHub after merge