### PR TITLE
fix(search): return true ranking position, add optional type scope

### DIFF
--- a/app/routes/series_routes.py
+++ b/app/routes/series_routes.py
@@ -484,11 +484,54 @@ async def get_series_summary(
 @router.get("/series/search", response_model=List[RankedSeriesOut])
 async def search_series(
     query: str = Query(..., description="Search keyword"),
+    type: Optional[str] = Query(
+        None,
+        description=(
+            "Optional series type (MANGA/MANHWA/MANHUA). When provided, both the "
+            "results and the rank are scoped to that category, so each result keeps "
+            "its true rank within the type. When omitted, ranks reflect the full "
+            "'All' ranking."
+        ),
+    ),
     db: AsyncSession = Depends(get_db)
 ):
-    stmt = select(Series, SeriesDetail).join(
+    def safe_avg(total, count):
+        return total / count if count else 0
+
+    def compute_final_score(detail) -> Decimal:
+        if not detail:
+            return Decimal(0)
+        story = safe_avg(detail.story_total, detail.story_count)
+        chars = safe_avg(detail.characters_total, detail.characters_count)
+        world = safe_avg(detail.worldbuilding_total, detail.worldbuilding_count)
+        art = safe_avg(detail.art_total, detail.art_count)
+        drama = safe_avg(detail.drama_or_fight_total, detail.drama_or_fight_count)
+        return Decimal((story + chars + world + art + drama) / 5)
+
+    # 1) Build the FULL approved ranking (optionally scoped to a type) so that each
+    #    search result can keep its TRUE rank — its position in the overall ranking —
+    #    instead of being re-ranked among only the search matches.
+    full_stmt = select(Series, SeriesDetail).join(
         SeriesDetail, Series.id == SeriesDetail.series_id, isouter=True
-    ).where(
+    ).where(Series.approval_status == SeriesApprovalStatus.APPROVED.value)
+    if type:
+        full_stmt = full_stmt.where(Series.type == type.upper())
+
+    full_rows = (await db.execute(full_stmt)).all()
+
+    scored = [(series.id, compute_final_score(detail)) for series, detail in full_rows]
+    score_by_id = {sid: score for sid, score in scored}
+
+    # Only series with a positive score are ranked; rank by score descending.
+    ranked_ids = sorted(
+        (entry for entry in scored if entry[1] > 0),
+        key=lambda entry: entry[1],
+        reverse=True,
+    )
+    rank_by_id = {sid: idx + 1 for idx, (sid, _) in enumerate(ranked_ids)}
+
+    # 2) Run the search query (scoped to the same type, when provided).
+    stmt = select(Series).where(
         and_(
             Series.approval_status == SeriesApprovalStatus.APPROVED.value,
             or_(
@@ -501,28 +544,14 @@ async def search_series(
             ),
         )
     )
+    if type:
+        stmt = stmt.where(Series.type == type.upper())
 
-    result = await db.execute(stmt)
-    results = result.all()
+    matches = (await db.execute(stmt)).scalars().all()
 
-    def safe_avg(total, count):
-        return total / count if count else 0
-
-    ranked_series = []
-    for series, detail in results:
-        if detail:
-            story = safe_avg(detail.story_total, detail.story_count)
-            chars = safe_avg(detail.characters_total, detail.characters_count)
-            world = safe_avg(detail.worldbuilding_total, detail.worldbuilding_count)
-            art = safe_avg(detail.art_total, detail.art_count)
-            drama = safe_avg(detail.drama_or_fight_total, detail.drama_or_fight_count)
-            # final_score = round((story + chars + world + art + drama) / 5, 2)
-            final_score = Decimal((story + chars + world + art + drama) / 5)
-
-        else:
-            final_score = 0.0
-
-        ranked_series.append({
+    payload = []
+    for series in matches:
+        payload.append({
             "id": series.id,
             "title": series.title,
             "genre": series.genre,
@@ -531,17 +560,13 @@ async def search_series(
             "artist": series.artist,
             "cover_url": series.cover_url,
             "vote_count": series.vote_count or 0,
-            "final_score": final_score,
+            # Reuse the score computed for the full ranking (every match is part of
+            # the approved set, so it is always present in score_by_id).
+            "final_score": score_by_id.get(series.id, Decimal(0)),
             "status": series.status.name if series.status else None,
+            "rank": rank_by_id.get(series.id),  # None for unranked (score 0)
         })
 
-    ranked = [s for s in ranked_series if s["final_score"] > 0]
-    unranked = [s for s in ranked_series if s["final_score"] == 0]
-
-    ranked.sort(key=lambda x: x["final_score"], reverse=True)
-    for idx, s in enumerate(ranked):
-        s["rank"] = idx + 1
-    for s in unranked:
-        s["rank"] = None
-
-    return ranked + unranked
+    # Present results in true-rank order, with unranked (rank None) last.
+    payload.sort(key=lambda item: (item["rank"] is None, item["rank"] or 0))
+    return payload

--- a/tests/series_routes_test.py
+++ b/tests/series_routes_test.py
@@ -200,3 +200,114 @@ def test_rankings_response_includes_required_fields():
     assert item["vote_count"] == 42
     assert "final_score" in item
     assert "rank" in item
+
+
+# ── /series/search: results must keep their TRUE rank, not a re-ranked position ──
+
+
+def make_detail(score):
+    """Detail whose every category averages to `score`, so final_score == score."""
+    return SimpleNamespace(
+        story_total=score, story_count=1,
+        characters_total=score, characters_count=1,
+        worldbuilding_total=score, worldbuilding_count=1,
+        art_total=score, art_count=1,
+        drama_or_fight_total=score, drama_or_fight_count=1,
+    )
+
+
+class FakeScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class FakeResult:
+    def __init__(self, rows=None, scalar_rows=None):
+        self._rows = rows or []
+        self._scalar_rows = scalar_rows or []
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        return FakeScalars(self._scalar_rows)
+
+
+class FakeQueuedSession:
+    """Returns queued results in order — one per execute() call.
+
+    The search endpoint executes twice: first the full ranking
+    (read via .all() of (series, detail) tuples), then the search matches
+    (read via .scalars().all()).
+    """
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._i = 0
+
+    async def execute(self, _stmt):
+        result = self._results[self._i]
+        self._i += 1
+        return result
+
+
+def test_search_results_keep_true_global_rank():
+    # Full ranking: scores 9,8,7,6 -> global ranks 1,2,3,4
+    full_rows = [
+        (make_series(id=1, title="Alpha", genre="Action"), make_detail(9)),
+        (make_series(id=2, title="Bravo", genre="Action"), make_detail(8)),
+        (make_series(id=3, title="Charlie Knight", genre="Action"), make_detail(7)),
+        (make_series(id=4, title="Delta Knight", genre="Action"), make_detail(6)),
+    ]
+    # Search for "knight" matches only the two lower-ranked series.
+    search_matches = [
+        make_series(id=3, title="Charlie Knight", genre="Action"),
+        make_series(id=4, title="Delta Knight", genre="Action"),
+    ]
+    session = FakeQueuedSession([
+        FakeResult(rows=full_rows),
+        FakeResult(scalar_rows=search_matches),
+    ])
+    cleanup = override_rankings_db(session)
+
+    try:
+        response = client.get("/series/search?query=knight")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    data = response.json()
+    ranks = {item["title"]: item["rank"] for item in data}
+    # Must reflect their position in the FULL ranking (3 and 4),
+    # NOT a re-ranked 1 and 2 among the matches.
+    assert ranks == {"Charlie Knight": 3, "Delta Knight": 4}
+
+
+def test_search_with_type_scopes_rank_within_type():
+    # Full ranking already scoped to MANHWA: scores 9,8 -> within-type ranks 1,2
+    full_rows = [
+        (make_series(id=11, title="Top Manhwa", genre="Action", type="MANHWA"), make_detail(9)),
+        (make_series(id=12, title="Second Manhwa", genre="Action", type="MANHWA"), make_detail(8)),
+    ]
+    search_matches = [
+        make_series(id=12, title="Second Manhwa", genre="Action", type="MANHWA"),
+    ]
+    session = FakeQueuedSession([
+        FakeResult(rows=full_rows),
+        FakeResult(scalar_rows=search_matches),
+    ])
+    cleanup = override_rankings_db(session)
+
+    try:
+        response = client.get("/series/search?query=manhwa&type=MANHWA")
+    finally:
+        cleanup()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "Second Manhwa"
+    assert data[0]["rank"] == 2  # its rank within MANHWA, not 1


### PR DESCRIPTION
## Summary
- /series/search now returns each result's true rank within the full approved ranking instead of re-ranking among matches
- Adds optional `type` param to scope both results and rank to a category (MANGA/MANHWA/MANHUA)
- Backward compatible: no `type` = global "All" ranks
- Adds tests for true-global-rank and within-type rank

## Test plan
- [ ] pytest tests/series_routes_test.py passes
- [ ] ruff clean
- [ ] Searching in All shows global ranks; searching in a category shows within-category ranks