### PR TITLE
feat(leaderboard): rank all non-admin users, newcomers at the bottom

### DIFF
--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel
-from sqlalchemy import select, func
+from sqlalchemy import select, func, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.routes.auth import get_db
@@ -120,17 +120,18 @@ async def get_leaderboard(
 ):
     """
     Ranked list of Rankers ordered by cred_score descending.
-    Only users with cred_score > 0 appear.
+    All non-admin users appear; new users with no activity (cred_score 0) sort to
+    the bottom and climb as they participate. Admins are excluded from ranking.
     """
     # Total ranked users (admins excluded)
     total_stmt = select(func.count(User.id)).where(
-        User.cred_score > 0,
         User.role != "ADMIN",
     )
     total = int((await db.execute(total_stmt)).scalar_one() or 0)
     total_pages = max(1, math.ceil(total / page_size))
 
-    # Page of ranked users with post counts and distinct series rated
+    # Page of users with post counts and distinct series rated. Ties (e.g. all the
+    # 0-cred newcomers) break by id ascending, so order is stable across pages.
     offset = (page - 1) * page_size
     stmt = (
         select(
@@ -140,7 +141,7 @@ async def get_leaderboard(
         )
         .outerjoin(ForumPost, ForumPost.author_id == User.id)
         .outerjoin(UserVote, UserVote.user_id == User.id)
-        .where(User.cred_score > 0, User.role != "ADMIN")
+        .where(User.role != "ADMIN")
         .group_by(User.id)
         .order_by(User.cred_score.desc(), User.id.asc())
         .offset(offset)
@@ -190,16 +191,22 @@ async def get_public_profile(
             detail=f"User '{username}' not found.",
         )
 
-    # ── Cred rank (None for admins and users with score 0) ───────────────
+    # ── Cred rank (None only for admins, who are excluded from ranking) ──────
+    # Every non-admin user is ranked, including newcomers with cred_score 0 (they
+    # sit at the bottom and climb as they participate). Uses the same tie-break as
+    # the leaderboard: higher cred first, then smaller id.
     cred_score = user.cred_score or 0
     rank: Optional[int] = None
-    if cred_score > 0 and user.role != "ADMIN":
+    if user.role != "ADMIN":
         rank_stmt = select(func.count(User.id)).where(
-            User.cred_score > cred_score,
             User.role != "ADMIN",
+            or_(
+                User.cred_score > cred_score,
+                and_(User.cred_score == cred_score, User.id < user.id),
+            ),
         )
-        users_above = int((await db.execute(rank_stmt)).scalar_one() or 0)
-        rank = users_above + 1
+        users_before = int((await db.execute(rank_stmt)).scalar_one() or 0)
+        rank = users_before + 1
 
     # ── Post count ────────────────────────────────────────────────────────
     post_count_stmt = select(func.count(ForumPost.id)).where(

--- a/docs/LEADERBOARD_NOTES.md
+++ b/docs/LEADERBOARD_NOTES.md
@@ -1,0 +1,27 @@
+# Leaderboard (Rankers) — Notes
+
+Endpoints: `GET /users/leaderboard` (list) and `GET /users/{username}` (per-profile rank).
+
+## Current behavior (as of backend-leaderboard-all-users)
+
+- **All non-admin users are ranked**, including newcomers with `cred_score = 0`.
+- Ordering: `cred_score DESC, id ASC`. Zero-activity users sort to the bottom and
+  climb as they earn cred. Ties break by `id` (older accounts first) so paging is stable.
+- **Admins are excluded** from ranking entirely (`rank = null` on their profile).
+  Do not change this.
+- A user's profile rank uses the **same tie-break** as the list, so the number on
+  their profile matches their position on the board.
+
+## Known future consideration (not a problem yet)
+
+With few users this is fine. **If the user base grows with many registered-but-inactive
+accounts**, the board becomes long and tail-heavy with 0-cred users. Options when/if that
+happens:
+
+1. Keep as-is (paginated) — simplest.
+2. Add a subtle visual split between **Ranked** (`cred_score > 0`) and **Newcomers**
+   (`cred_score = 0`) on the frontend.
+3. Add an optional `?active_only=true` query param to the leaderboard endpoint for an
+   "active rankers only" view, while still letting every profile show a rank.
+
+No action needed now — revisit when the tail gets noisy.


### PR DESCRIPTION
## Summary
- Leaderboard now lists all non-admin users instead of only those with cred_score > 0; zero-activity users sort to the bottom and climb as they participate
- Per-profile rank now computed for every non-admin user (including cred 0), using the same tie-break as the leaderboard (cred desc, then id asc) so profile rank matches board position
- Admin exclusion from ranking is unchanged

## Test plan
- [ ] /users/leaderboard includes new/zero-cred users at the bottom; admins excluded
- [ ] New user's profile shows a rank (not blank); improves as they earn cred
- [ ] Profile rank matches the user's position on the leaderboard
- [ ] Pagination order stable across pages