### PR TITLE
style(email): color in email

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -92,8 +92,8 @@ The Toon Ranks team
                           <td style="vertical-align:middle;">
                             <img src="{escaped_logo_url}" width="42" height="42" alt="" style="display:block;border-radius:12px;border:0;">
                           </td>
-                          <td style="vertical-align:middle;padding-left:12px;font-size:13px;line-height:18px;font-weight:800;letter-spacing:2.8px;color:#182235;">
-                            TOON RANKS
+                          <td style="vertical-align:middle;padding-left:12px;font-size:13px;line-height:18px;font-weight:800;letter-spacing:2.8px;">
+                            <span style="color:#2563eb;">TOON</span> <span style="color:#182235;">RANKS</span>
                           </td>
                         </tr>
                       </table>
@@ -230,8 +230,8 @@ The Toon Ranks team
                           <td style="vertical-align:middle;">
                             <img src="{escaped_logo_url}" width="42" height="42" alt="" style="display:block;border-radius:12px;border:0;">
                           </td>
-                          <td style="vertical-align:middle;padding-left:12px;font-size:13px;line-height:18px;font-weight:800;letter-spacing:2.8px;color:#182235;">
-                            TOON RANKS
+                          <td style="vertical-align:middle;padding-left:12px;font-size:13px;line-height:18px;font-weight:800;letter-spacing:2.8px;">
+                            <span style="color:#2563eb;">TOON</span> <span style="color:#182235;">RANKS</span>
                           </td>
                         </tr>
                       </table>

--- a/tests/email_service_test.py
+++ b/tests/email_service_test.py
@@ -41,7 +41,10 @@ def test_build_verification_email_includes_plain_text_and_html_parts(monkeypatch
     assert "If you have questions, contact support@toonranks.com." in body
     assert "reply to this email" not in body.lower()
     assert "reply here" not in html.lower()
-    assert "TOON RANKS" in html
+    # Header wordmark is split into two spans so "TOON" can use the brand blue
+    # (matching the site logo); assert both parts are present.
+    assert ">TOON</span>" in html
+    assert ">RANKS</span>" in html
     assert "Confirm your Toon Ranks email" in html
     assert "Confirm email" in html
     assert "saved series, category ratings, and forum discussions" in html


### PR DESCRIPTION
Updates the wordmark text in the transactional email header (verification + password reset templates) so "TOON" uses the brand blue (#2563eb) and "RANKS" stays dark, matching the website logo. Solid blue used instead of the site's gradient since email clients don't reliably render gradient text. No logic change.