### PR TITLE
Add public-profile ratings/posts with per-user visibility toggles

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -170,6 +170,24 @@ async def on_startup():
                     text(
                         """
                         ALTER TABLE IF EXISTS man_review.users
+                        ADD COLUMN IF NOT EXISTS public_ratings BOOLEAN
+                        NOT NULL DEFAULT TRUE
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
+                        ALTER TABLE IF EXISTS man_review.users
+                        ADD COLUMN IF NOT EXISTS public_posts BOOLEAN
+                        NOT NULL DEFAULT TRUE
+                        """
+                    )
+                )
+                await conn.execute(
+                    text(
+                        """
+                        ALTER TABLE IF EXISTS man_review.users
                         ADD COLUMN IF NOT EXISTS auth_provider VARCHAR(10)
                         NOT NULL DEFAULT 'email'
                         """

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -21,5 +21,14 @@ class User(Base):
     registered_at = Column(DateTime(timezone=True), nullable=True)
     cred_score = Column(Integer, nullable=False, server_default="0", default=0)
 
+    # Public-profile visibility toggles. Default ON: rated series and forum
+    # posts show on the user's public profile unless they opt out in settings.
+    public_ratings = Column(
+        Boolean, nullable=False, server_default="true", default=True
+    )
+    public_posts = Column(
+        Boolean, nullable=False, server_default="true", default=True
+    )
+
     reading_lists = relationship("ReadingList", cascade="all, delete-orphan", backref="owner")
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -20,6 +20,8 @@ from app.schemas.user_schemas import (
     UserRoleUpdate,
     UsernameUpdateRequest,
     UsernameUpdateOut,
+    PrivacySettingsUpdate,
+    PrivacySettingsOut,
 )
 from sqlalchemy.future import select
 from passlib.hash import bcrypt
@@ -98,6 +100,8 @@ def user_to_dict(user: User) -> dict:
         "role": user.role,
         "avatar_url": getattr(user, "avatar_url", None),
         "avatar_preset": getattr(user, "avatar_preset", None) or DEFAULT_AVATAR_PRESET,
+        "public_ratings": getattr(user, "public_ratings", True),
+        "public_posts": getattr(user, "public_posts", True),
     }
 
 
@@ -790,6 +794,32 @@ async def update_my_username(
     # own session and is not persistent in db, so we must re-fetch it here.
     user = await get_user_for_update(current_user, db)
     user.username = new_username
+    await db.commit()
+    await db.refresh(user)
+
+    return user
+
+
+@router.patch("/me/privacy", response_model=PrivacySettingsOut)
+@limiter.limit("20/hour")
+async def update_my_privacy(
+    request: Request,
+    payload: PrivacySettingsUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update the authenticated user's public-profile visibility toggles.
+    Controls whether the user's rated series and forum posts appear on their
+    public profile. Either field may be omitted to leave it unchanged.
+    """
+    user = await get_user_for_update(current_user, db)
+
+    if payload.public_ratings is not None:
+        user.public_ratings = payload.public_ratings
+    if payload.public_posts is not None:
+        user.public_posts = payload.public_posts
+
     await db.commit()
     await db.refresh(user)
 

--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -13,10 +13,24 @@ from app.models.user_model import User
 from app.models.user_favourite import UserFavourite
 from app.models.series_model import Series
 from app.models.reading_list import ReadingList, ReadingListItem
-from app.models.forum_model import ForumPost
+from app.models.forum_model import ForumPost, ForumThread
 from app.models.user_vote import UserVote
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+# Caps for the public profile lists so the payload stays small. The owner's own
+# Account page (paginated endpoints) remains the place to browse everything.
+PUBLIC_RATINGS_LIMIT = 30
+PUBLIC_POSTS_LIMIT = 20
+POST_EXCERPT_CHARS = 200
+
+
+def _excerpt(markdown: str) -> str:
+    """A short, plain-ish preview of a forum post for the public profile."""
+    text = " ".join((markdown or "").split())
+    if len(text) <= POST_EXCERPT_CHARS:
+        return text
+    return text[:POST_EXCERPT_CHARS].rstrip() + "…"
 
 
 # ── Schemas ───────────────────────────────────────────────────────────────────
@@ -39,6 +53,26 @@ class PublicReadingListOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class PublicSeriesRatingOut(BaseModel):
+    series_id: int
+    title: Optional[str]
+    cover_url: Optional[str]
+    type: Optional[str]
+    score: float  # the user's own average across the categories they scored
+
+    model_config = {"from_attributes": True}
+
+
+class PublicForumPostOut(BaseModel):
+    post_id: int
+    thread_id: int
+    thread_title: Optional[str]
+    excerpt: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 class PublicProfileOut(BaseModel):
     username: str
     role: str
@@ -50,6 +84,9 @@ class PublicProfileOut(BaseModel):
     post_count: int
     favourites: List[PublicFavouriteOut]
     reading_lists: List[PublicReadingListOut]
+    # None when the user has hidden that section (vs [] meaning "public but empty").
+    ratings: Optional[List[PublicSeriesRatingOut]] = None
+    posts: Optional[List[PublicForumPostOut]] = None
 
     model_config = {"from_attributes": True}
 
@@ -257,6 +294,59 @@ async def get_public_profile(
         for rl, item_count in rl_rows
     ]
 
+    # ── Rated series (only if the user keeps ratings public) ───────────────
+    # One row per series the user has voted on, with their own average score
+    # across the categories they scored. Capped to the most recent set.
+    ratings: Optional[List[PublicSeriesRatingOut]] = None
+    if user.public_ratings:
+        rating_stmt = (
+            select(
+                UserVote.series_id,
+                func.avg(UserVote.score).label("avg_score"),
+                Series.title,
+                Series.cover_url,
+                Series.type,
+            )
+            .join(Series, Series.id == UserVote.series_id)
+            .where(UserVote.user_id == user.id)
+            .group_by(UserVote.series_id, Series.title, Series.cover_url, Series.type)
+            .order_by(UserVote.series_id.desc())
+            .limit(PUBLIC_RATINGS_LIMIT)
+        )
+        rating_rows = (await db.execute(rating_stmt)).all()
+        ratings = [
+            PublicSeriesRatingOut(
+                series_id=series_id,
+                title=title,
+                cover_url=cover_url,
+                type=stype.value if stype else None,
+                score=round(float(avg_score), 1),
+            )
+            for series_id, avg_score, title, cover_url, stype in rating_rows
+        ]
+
+    # ── Forum posts (only if the user keeps posts public) ──────────────────
+    posts: Optional[List[PublicForumPostOut]] = None
+    if user.public_posts:
+        post_stmt = (
+            select(ForumPost, ForumThread.title)
+            .join(ForumThread, ForumThread.id == ForumPost.thread_id)
+            .where(ForumPost.author_id == user.id)
+            .order_by(ForumPost.created_at.desc())
+            .limit(PUBLIC_POSTS_LIMIT)
+        )
+        post_rows = (await db.execute(post_stmt)).all()
+        posts = [
+            PublicForumPostOut(
+                post_id=post.id,
+                thread_id=post.thread_id,
+                thread_title=thread_title,
+                excerpt=_excerpt(post.content_markdown),
+                created_at=post.created_at,
+            )
+            for post, thread_title in post_rows
+        ]
+
     return PublicProfileOut(
         username=user.username,
         role=user.role or "GENERAL",
@@ -268,4 +358,6 @@ async def get_public_profile(
         post_count=post_count,
         favourites=favourites,
         reading_lists=reading_lists,
+        ratings=ratings,
+        posts=posts,
     )

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -94,3 +94,16 @@ class UsernameUpdateOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class PrivacySettingsUpdate(BaseModel):
+    # Both optional so a client can update one toggle without touching the other.
+    public_ratings: Optional[bool] = None
+    public_posts: Optional[bool] = None
+
+
+class PrivacySettingsOut(BaseModel):
+    public_ratings: bool
+    public_posts: bool
+
+    model_config = {"from_attributes": True}
+
+

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -239,6 +239,8 @@ def test_login_returns_access_token_for_verified_user(monkeypatch):
             "role": "GENERAL",
             "avatar_url": None,
             "avatar_preset": "blue",
+            "public_ratings": True,
+            "public_posts": True,
         },
     }
 
@@ -508,6 +510,33 @@ def test_create_mobile_auth_code_rejects_unknown_redirect_uri():
     assert session.committed is False
 
 
+def test_update_my_privacy_toggles_only_provided_flag():
+    db_user = SimpleNamespace(
+        id=7,
+        username="reader",
+        role="GENERAL",
+        public_ratings=True,
+        public_posts=True,
+    )
+    current_user = SimpleNamespace(id=7, username="reader", role="GENERAL")
+    session = FakeAuthSession(get_result=db_user)
+    cleanup_db = override_auth_db(session)
+    cleanup_user = override_auth_user(current_user)
+
+    try:
+        response = client.patch("/auth/me/privacy", json={"public_posts": False})
+    finally:
+        cleanup_user()
+        cleanup_db()
+
+    assert response.status_code == 200
+    # Only public_posts was sent, so public_ratings is left untouched.
+    assert response.json() == {"public_ratings": True, "public_posts": False}
+    assert db_user.public_ratings is True
+    assert db_user.public_posts is False
+    assert session.committed is True
+
+
 def test_exchange_mobile_auth_code_returns_tokens_and_marks_code_used(monkeypatch):
     auth_code = SimpleNamespace(
         user_id=7,
@@ -545,6 +574,8 @@ def test_exchange_mobile_auth_code_returns_tokens_and_marks_code_used(monkeypatc
             "role": "CONTRIBUTOR",
             "avatar_url": "https://cdn.example.com/avatar.webp",
             "avatar_preset": "emerald",
+            "public_ratings": True,
+            "public_posts": True,
         },
     }
     assert body["refresh_token"]
@@ -600,6 +631,8 @@ def test_refresh_mobile_access_token_returns_new_access_token(monkeypatch):
             "role": "GENERAL",
             "avatar_url": None,
             "avatar_preset": "blue",
+            "public_ratings": True,
+            "public_posts": True,
         },
     }
     assert refresh_record.last_used_at is not None


### PR DESCRIPTION
## Summary
- New user flags public_ratings / public_posts (default true) + startup migration.
- PATCH /auth/me/privacy to toggle them; flags included in the login user object.
- get_public_profile now returns the user's rated series (avg score, capped 30)
  and recent forum posts (capped 20), each gated on its flag (null when hidden).

## Test plan
- [ ] pytest green (incl. new privacy endpoint test)
- [ ] PATCH /auth/me/privacy updates the right flag, leaves the other untouched
- [ ] GET /users/{username} shows/hides ratings & posts per the flags
- [ ] Login payload includes the two flags